### PR TITLE
documentation: Get Read the Docs working

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,4 +17,6 @@ formats:
 python:
   version: 3.7
   install:
+    - method: pip
+      path: .
     - requirements: doc/requirements.txt

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,9 +30,9 @@ htmlhelp_basename = "{}doc".format(project)
 
 napoleon_use_rtype = False
 
-apidoc_module_dir = '../src/braket'
-apidoc_output_dir = '_apidoc'
-apidoc_excluded_paths = ['../test']
+apidoc_module_dir = "../src/braket"
+apidoc_output_dir = "_apidoc"
+apidoc_excluded_paths = ["../test"]
 apidoc_separate_modules = True
 apidoc_module_first = True
 apidoc_extra_args = ["-f", "--implicit-namespaces", "-H", "API Reference"]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,11 +1,7 @@
 """Sphinx configuration."""
 import datetime
-import os
-import sys
 
 import pkg_resources
-
-sys.path.insert(0, os.path.abspath("../src/"))
 
 # Sphinx configuration below.
 project = "amazon-braket-default-simulator"
@@ -14,6 +10,7 @@ release = version
 copyright = "{}, Amazon.com".format(datetime.datetime.now().year)
 
 extensions = [
+    "sphinxcontrib.apidoc",
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
@@ -32,6 +29,13 @@ html_theme = "sphinx_rtd_theme"
 htmlhelp_basename = "{}doc".format(project)
 
 napoleon_use_rtype = False
+
+apidoc_module_dir = '../src/braket'
+apidoc_output_dir = '_apidoc'
+apidoc_excluded_paths = ['../test']
+apidoc_separate_modules = True
+apidoc_module_first = True
+apidoc_extra_args = ["-f", "--implicit-namespaces", "-H", "API Reference"]
 
 
 # -- Options for MathJax output -------------------------------------------

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,7 +1,11 @@
 """Sphinx configuration."""
 import datetime
+import os
+import sys
 
 import pkg_resources
+
+sys.path.insert(0, os.path.abspath("../src/"))
 
 # Sphinx configuration below.
 project = "amazon-braket-default-simulator"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,7 +7,7 @@ that you can run locally.
 Here you'll find an overview and API documentation for Amazon Braket Default Simulator Python.
 The project homepage is in GitHub, https://github.com/aws/amazon-braket-default-simulator-python, where you can find the source and installation instructions for the library.
 
-.. automodule:: my_project.main
+.. automodule:: braket
     :members:
 
 .. toctree::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,10 +7,16 @@ that you can run locally.
 Here you'll find an overview and API documentation for Amazon Braket Default Simulator Python.
 The project homepage is in GitHub, https://github.com/aws/amazon-braket-default-simulator-python, where you can find the source and installation instructions for the library.
 
+.. automodule:: my_project.main
+    :members:
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
 Indices and tables
 __________________
 
-* :doc:`_apidoc/modules`
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -7,16 +7,10 @@ that you can run locally.
 Here you'll find an overview and API documentation for Amazon Braket Default Simulator Python.
 The project homepage is in GitHub, https://github.com/aws/amazon-braket-default-simulator-python, where you can find the source and installation instructions for the library.
 
-.. automodule:: braket
-    :members:
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
-
 Indices and tables
 __________________
 
+* :doc:`_apidoc/modules`
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx-rtd-theme
+sphinxcontrib-apidoc

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
             "pytest-xdist",
             "sphinx",
             "sphinx-rtd-theme",
+            "sphinxcontrib-apidoc",
             "tox",
         ]
     },

--- a/tox.ini
+++ b/tox.ini
@@ -53,8 +53,8 @@ basepython = python3.7
 deps =
     sphinx
     sphinx-rtd-theme
+    sphinxcontrib-apidoc
 commands =
-    sphinx-apidoc -e -f -M --implicit-namespaces -H "API Reference" -o doc/_apidoc src/braket
     sphinx-build -E -T -b html doc build/documentation/html
 
 [testenv:serve-docs]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fixed previously failing Read the Docs builds by:
1. Explicity adding `method` and `path` to .readthedocs.yml; this was causing builds to fail altogether
2. Using [sphinxcontrib-apidoc](https://github.com/sphinx-contrib/apidoc) instead autodoc directly (see readthedocs/readthedocs.org#1139). Defore, our `tox -e docs` command would run `aphinx-apidoc` then `sphinx-build`. However, Read the Docs only runs `sphinx-build`, so the module docs would never get generated.

*Testing done:*

[build_files.tar.gz](https://github.com/aws/amazon-braket-default-simulator-python/files/5077349/build_files.tar.gz)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
