### PR TITLE
change: Enable simultaneous measurement of observables with shared factors

### DIFF
--- a/src/braket/default_simulator/gate_operations.py
+++ b/src/braket/default_simulator/gate_operations.py
@@ -18,9 +18,9 @@ import math
 from functools import singledispatch
 from typing import Tuple
 
+import braket.ir.jaqcd as braket_instruction
 import numpy as np
 
-import braket.ir.jaqcd as braket_instruction
 from braket.default_simulator.operation import GateOperation
 from braket.default_simulator.operation_helpers import (
     check_matrix_dimensions,

--- a/src/braket/default_simulator/result_types.py
+++ b/src/braket/default_simulator/result_types.py
@@ -19,6 +19,7 @@ from functools import singledispatch
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
+from braket.ir import jaqcd
 
 from braket.default_simulator.observables import (
     Hadamard,
@@ -32,7 +33,6 @@ from braket.default_simulator.observables import (
 from braket.default_simulator.operation import Observable
 from braket.default_simulator.operation_helpers import ir_matrix_to_ndarray
 from braket.default_simulator.simulation import StateVectorSimulation
-from braket.ir import jaqcd
 
 
 def from_braket_result_type(result_type) -> ResultType:

--- a/test/performance/test_performance.py
+++ b/test/performance/test_performance.py
@@ -15,10 +15,10 @@ import itertools
 import json
 import random
 
+import braket.ir.jaqcd as jaqcd
 import numpy as np
 import pytest
 
-import braket.ir.jaqcd as jaqcd
 from braket.default_simulator.simulator import DefaultSimulator
 
 results_data = [

--- a/test/unit_tests/braket/default_simulator/test_gate_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_gate_operations.py
@@ -11,12 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import pytest
-
 import braket.ir.jaqcd as instruction
+import pytest
+from braket.ir.jaqcd import shared_models
+
 from braket.default_simulator import gate_operations
 from braket.default_simulator.operation_helpers import check_unitary
-from braket.ir.jaqcd import shared_models
 
 testdata = [
     (instruction.I(target=4), (4,), gate_operations.Identity),

--- a/test/unit_tests/braket/default_simulator/test_result_types.py
+++ b/test/unit_tests/braket/default_simulator/test_result_types.py
@@ -15,6 +15,8 @@ import cmath
 
 import numpy as np
 import pytest
+from braket.ir import jaqcd
+from braket.ir.jaqcd import shared_models
 
 from braket.default_simulator import StateVectorSimulation
 from braket.default_simulator.observables import Hadamard, PauliX, TensorProduct
@@ -26,8 +28,6 @@ from braket.default_simulator.result_types import (
     Variance,
     from_braket_result_type,
 )
-from braket.ir import jaqcd
-from braket.ir.jaqcd import shared_models
 
 NUM_SAMPLES = 1000
 

--- a/test/unit_tests/braket/default_simulator/test_simulator.py
+++ b/test/unit_tests/braket/default_simulator/test_simulator.py
@@ -18,17 +18,17 @@ from collections import Counter, namedtuple
 
 import numpy as np
 import pytest
-
-from braket.default_simulator import gate_operations, observables
-from braket.default_simulator.result_types import Expectation, Variance
-from braket.default_simulator.simulator import DefaultSimulator
 from braket.device_schema.simulators import (
     GateModelSimulatorDeviceCapabilities,
     GateModelSimulatorDeviceParameters,
 )
 from braket.ir.jaqcd import Program
-from braket.simulator import BraketSimulator
 from braket.task_result import AdditionalMetadata, ResultTypeValue, TaskMetadata
+
+from braket.default_simulator import gate_operations, observables
+from braket.default_simulator.result_types import Expectation, Variance
+from braket.default_simulator.simulator import DefaultSimulator
+from braket.simulator import BraketSimulator
 
 CircuitData = namedtuple("CircuitData", "circuit_ir probability_zero")
 
@@ -506,15 +506,19 @@ def test_validate_and_consolidate_observable_result_types_tensor_product():
         Expectation(observables.TensorProduct([observables.PauliX([2]), observables.PauliY([3])])),
     ]
     actual_obs = DefaultSimulator._validate_and_consolidate_observable_result_types(obs_rts, 4)
-    assert len(actual_obs) == 2
-    assert actual_obs[0].measured_qubits == (
-        0,
-        1,
-    )
-    assert actual_obs[1].measured_qubits == (
-        2,
-        3,
-    )
+    assert len(actual_obs) == 4
+    assert [obs.measured_qubits for obs in actual_obs] == [(0,), (1,), (2,), (3,)]
+
+
+def test_validate_and_consolidate_observable_result_types_tensor_product_commuting():
+    obs_rts = [
+        Expectation(observables.PauliX([0])),
+        Variance(observables.TensorProduct([observables.PauliX([0]), observables.PauliY([1])])),
+        Expectation(observables.TensorProduct([observables.PauliY([1]), observables.PauliX([2])])),
+    ]
+    actual_obs = DefaultSimulator._validate_and_consolidate_observable_result_types(obs_rts, 3)
+    assert len(actual_obs) == 3
+    assert [obs.measured_qubits for obs in actual_obs] == [(0,), (1,), (2,)]
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/braket/default_simulator/test_simulator.py
+++ b/test/unit_tests/braket/default_simulator/test_simulator.py
@@ -521,6 +521,46 @@ def test_validate_and_consolidate_observable_result_types_tensor_product_commuti
     assert [obs.measured_qubits for obs in actual_obs] == [(0,), (1,), (2,)]
 
 
+def test_validate_and_consolidate_observable_result_types_tensor_product_hermitian_commuting():
+    obs_rts = [
+        Expectation(observables.PauliX([0])),
+        Variance(
+            observables.TensorProduct(
+                [
+                    observables.PauliX([0]),
+                    observables.Hermitian(np.eye(4), [1, 2]),
+                    observables.PauliY([3]),
+                ]
+            )
+        ),
+        Expectation(
+            observables.TensorProduct(
+                [observables.Hermitian(np.eye(4), [1, 2]), observables.PauliY([3])]
+            )
+        ),
+    ]
+    actual_obs = DefaultSimulator._validate_and_consolidate_observable_result_types(obs_rts, 4)
+    assert len(actual_obs) == 3
+    assert [obs.measured_qubits for obs in actual_obs] == [
+        (0,),
+        (
+            1,
+            2,
+        ),
+        (3,),
+    ]
+
+
+def test_observable_hash_tensor_product():
+    matrix = np.eye(4)
+    obs = observables.TensorProduct(
+        [observables.PauliX([0]), observables.Hermitian(matrix, [1, 2]), observables.PauliY([1])]
+    )
+    hash_dict = DefaultSimulator._observable_hash(obs)
+    matrix_hash = hash_dict[1]
+    assert hash_dict == {0: "PauliX", 1: matrix_hash, 2: matrix_hash, 3: "PauliY"}
+
+
 @pytest.mark.parametrize(
     "obs1,obs2",
     [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Allow simultaneous measurement of commuting observables, e.g. expectation(Pauli-X(0)), and variance(TensorProduct([PauliX(0), PauliY(1)]))

*Testing done:*
* Added unit test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
