### PR TITLE
feature: Always accept identity observable factors

### DIFF
--- a/src/braket/default_simulator/gate_operations.py
+++ b/src/braket/default_simulator/gate_operations.py
@@ -18,9 +18,9 @@ import math
 from functools import singledispatch
 from typing import Tuple
 
-import braket.ir.jaqcd as braket_instruction
 import numpy as np
 
+import braket.ir.jaqcd as braket_instruction
 from braket.default_simulator.operation import GateOperation
 from braket.default_simulator.operation_helpers import (
     check_matrix_dimensions,

--- a/src/braket/default_simulator/result_types.py
+++ b/src/braket/default_simulator/result_types.py
@@ -19,7 +19,6 @@ from functools import singledispatch
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
-from braket.ir import jaqcd
 
 from braket.default_simulator.observables import (
     Hadamard,
@@ -33,6 +32,7 @@ from braket.default_simulator.observables import (
 from braket.default_simulator.operation import Observable
 from braket.default_simulator.operation_helpers import ir_matrix_to_ndarray
 from braket.default_simulator.simulation import StateVectorSimulation
+from braket.ir import jaqcd
 
 
 def from_braket_result_type(result_type) -> ResultType:

--- a/src/braket/default_simulator/simulator.py
+++ b/src/braket/default_simulator/simulator.py
@@ -15,20 +15,10 @@ import sys
 import uuid
 from typing import Any, Callable, Dict, List, Tuple, Union
 
-from braket.device_schema.simulators import (
-    GateModelSimulatorDeviceCapabilities,
-    GateModelSimulatorDeviceParameters,
-)
-from braket.ir.jaqcd import Program
-from braket.task_result import (
-    AdditionalMetadata,
-    GateModelTaskResult,
-    ResultTypeValue,
-    TaskMetadata,
-)
+import numpy as np
 
 from braket.default_simulator.gate_operations import from_braket_instruction
-from braket.default_simulator.observables import Hermitian, TensorProduct
+from braket.default_simulator.observables import Hermitian, Identity, TensorProduct
 from braket.default_simulator.operation import Observable, Operation
 from braket.default_simulator.result_types import (
     ObservableResultType,
@@ -36,7 +26,18 @@ from braket.default_simulator.result_types import (
     from_braket_result_type,
 )
 from braket.default_simulator.simulation import StateVectorSimulation
+from braket.device_schema.simulators import (
+    GateModelSimulatorDeviceCapabilities,
+    GateModelSimulatorDeviceParameters,
+)
+from braket.ir.jaqcd import Program
 from braket.simulator import BraketSimulator
+from braket.task_result import (
+    AdditionalMetadata,
+    GateModelTaskResult,
+    ResultTypeValue,
+    TaskMetadata,
+)
 
 
 class DefaultSimulator(BraketSimulator):
@@ -184,10 +185,19 @@ class DefaultSimulator(BraketSimulator):
                 f"All qubits are already being measured in {unique_none_observables[0]};"
                 f"cannot measure in {unique_none_observables[1:]}"
             )
+        not_none_observable_list = DefaultSimulator._assign_observables_to_qubits(
+            observable_result_types, none_observable_mapping, qubit_count
+        )
+        return not_none_observable_list + unique_none_observables
+
+    @staticmethod
+    def _assign_observables_to_qubits(
+        observable_result_types, none_observable_mapping, qubit_count
+    ):
         not_none_observable_list = []
         qubit_observable_mapping = {}
+        identity_qubits = set()
         for result_type in observable_result_types:
-            new_obs = DefaultSimulator._observable_hash(result_type.observable)
             obs_obj = (
                 DefaultSimulator._tensor_product_index_dict(result_type.observable, lambda x: x)
                 if isinstance(result_type.observable, TensorProduct)
@@ -202,32 +212,96 @@ class DefaultSimulator(BraketSimulator):
                     f"Result type ({result_type.__class__.__name__}) Observable "
                     f"({obs_obj.__class__.__name__}) references invalid qubits {measured_qubits}"
                 )
+            new_obs = DefaultSimulator._observable_hash(result_type.observable)
             for i in range(len(measured_qubits)):
-                qubit = measured_qubits[i]
-                new_qubit_obs = new_obs[i] if isinstance(new_obs, dict) else new_obs
-                # Validate that the same observable is requested for a qubit in the result types
-                existing_obs = qubit_observable_mapping.get(qubit)
-                if existing_obs:
-                    if existing_obs != new_qubit_obs:
-                        raise ValueError(
-                            f"Qubit {qubit} is already being measured in {existing_obs};"
-                            f" cannot measure in {new_obs}."
-                        )
-                else:
-                    qubit_observable_mapping[qubit] = new_qubit_obs
-                    qubit_obs_obj = obs_obj[i] if isinstance(obs_obj, dict) else obs_obj
-                    if (
-                        not none_observable_mapping.get(new_qubit_obs)
-                        and qubit_obs_obj.measured_qubits.index(qubit) == 0
-                    ):
-                        qubit_obs_obj = obs_obj[i] if isinstance(obs_obj, dict) else obs_obj
-                        not_none_observable_list.append(qubit_obs_obj)
-        return not_none_observable_list + unique_none_observables
+                DefaultSimulator._assign_observable(
+                    obs_obj,
+                    new_obs,
+                    measured_qubits,
+                    i,
+                    not_none_observable_list,
+                    qubit_observable_mapping,
+                    none_observable_mapping,
+                    identity_qubits,
+                )
+        for i in sorted(identity_qubits):
+            not_none_observable_list.append(Identity([i]))
+        return not_none_observable_list
+
+    @staticmethod
+    def _assign_observable(
+        whole_observable,
+        hashed_qubit_observable,
+        measured_qubits,
+        target_index,
+        not_none_observable_list,
+        qubit_observable_mapping,
+        none_observable_mapping,
+        identity_qubits,
+    ):
+        # Validate that the same observable is requested for a qubit in the result types
+        hashed_qubit_observable = (
+            hashed_qubit_observable[target_index]
+            if isinstance(hashed_qubit_observable, dict)
+            else hashed_qubit_observable
+        )
+        qubit = measured_qubits[target_index]
+        existing_observable = qubit_observable_mapping.get(qubit)
+        if hashed_qubit_observable == Identity.__name__:
+            if qubit not in qubit_observable_mapping:
+                identity_qubits.add(qubit)
+            # Do nothing if non-identity observable already exists on the qubit
+        else:
+            qubit_observable = (
+                whole_observable[target_index]
+                if isinstance(whole_observable, dict)
+                else whole_observable
+            )
+            if not existing_observable:
+                identity_qubits.discard(qubit)
+                qubit_observable_mapping[qubit] = qubit_observable
+
+                if (
+                    not none_observable_mapping.get(hashed_qubit_observable)
+                    and qubit_observable.measured_qubits.index(qubit) == 0
+                ):
+                    not_none_observable_list.append(qubit_observable)
+            else:
+                DefaultSimulator._validate_same_observable(
+                    existing_observable, qubit_observable, qubit
+                )
+
+    @staticmethod
+    def _validate_same_observable(existing, new, qubit):
+        cls_existing = existing.__class__.__name__
+        cls_new = new.__class__.__name__
+        if cls_existing != cls_new:
+            raise ValueError(
+                f"Qubit {qubit} is already being measured in {cls_existing};"
+                f" cannot measure in {cls_new}."
+            )
+        if cls_existing == Hermitian.__name__:
+            if not np.allclose(existing.matrix, new.matrix):
+                raise ValueError(
+                    f"Qubit {qubit} is already being measured in {existing.matrix};"
+                    f" cannot measure in {new.matrix}."
+                )
+            qubits_existing = existing.measured_qubits
+            qubits_new = new.measured_qubits
+            if (
+                qubits_existing is not None
+                and len(qubits_existing) > 1
+                and qubits_existing != qubits_new
+            ):
+                raise ValueError(
+                    f"Existing measured qubits {qubits_existing} of observable {cls_existing}"
+                    f" conflict with new measured qubits {qubits_new}."
+                )
 
     @staticmethod
     def _tensor_product_index_dict(
         observable: TensorProduct, callable: Callable[[Observable], Any]
-    ) -> Dict[int, Observable]:
+    ) -> Dict[int, Any]:
         obj_dict = {}
         i = 0
         factors = list(observable.factors)

--- a/test/performance/test_performance.py
+++ b/test/performance/test_performance.py
@@ -15,10 +15,10 @@ import itertools
 import json
 import random
 
-import braket.ir.jaqcd as jaqcd
 import numpy as np
 import pytest
 
+import braket.ir.jaqcd as jaqcd
 from braket.default_simulator.simulator import DefaultSimulator
 
 results_data = [

--- a/test/unit_tests/braket/default_simulator/test_gate_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_gate_operations.py
@@ -11,12 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-import braket.ir.jaqcd as instruction
 import pytest
-from braket.ir.jaqcd import shared_models
 
+import braket.ir.jaqcd as instruction
 from braket.default_simulator import gate_operations
 from braket.default_simulator.operation_helpers import check_unitary
+from braket.ir.jaqcd import shared_models
 
 testdata = [
     (instruction.I(target=4), (4,), gate_operations.Identity),

--- a/test/unit_tests/braket/default_simulator/test_result_types.py
+++ b/test/unit_tests/braket/default_simulator/test_result_types.py
@@ -15,8 +15,6 @@ import cmath
 
 import numpy as np
 import pytest
-from braket.ir import jaqcd
-from braket.ir.jaqcd import shared_models
 
 from braket.default_simulator import StateVectorSimulation
 from braket.default_simulator.observables import Hadamard, PauliX, TensorProduct
@@ -28,6 +26,8 @@ from braket.default_simulator.result_types import (
     Variance,
     from_braket_result_type,
 )
+from braket.ir import jaqcd
+from braket.ir.jaqcd import shared_models
 
 NUM_SAMPLES = 1000
 


### PR DESCRIPTION
This enables simultaneous measurement of qubit-wise commuting Pauli
words.

Also added validation to make sure Hermitian observables on more than 1
qubit that share a target qubit share all target qubits and in the same
order.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
