### PR TITLE
change: Make tensor products more efficient

### DIFF
--- a/src/braket/default_simulator/observables.py
+++ b/src/braket/default_simulator/observables.py
@@ -18,7 +18,8 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
-from braket.default_simulator.operation import Observable
+from braket.default_simulator import gate_operations
+from braket.default_simulator.operation import GateOperation, Observable
 from braket.default_simulator.operation_helpers import (
     check_hermitian,
     check_matrix_dimensions,
@@ -51,9 +52,8 @@ class Identity(Observable):
     def eigenvalues(self) -> np.ndarray:
         return np.array([1, 1])
 
-    @property
-    def diagonalizing_matrix(self) -> Optional[np.ndarray]:
-        return None
+    def diagonalizing_gates(self, num_qubits: Optional[int] = None) -> Tuple[GateOperation, ...]:
+        return ()
 
 
 class Hadamard(Observable):
@@ -81,13 +81,14 @@ class Hadamard(Observable):
     def eigenvalues(self) -> np.ndarray:
         return pauli_eigenvalues(1)
 
-    @property
-    def diagonalizing_matrix(self) -> Optional[np.ndarray]:
-        # RY(-\pi / 4)
-        angle = -math.pi / 4
-        cos_component = math.cos(angle / 2)
-        sin_component = math.sin(angle / 2)
-        return np.array([[cos_component, -sin_component], [sin_component, cos_component]])
+    def diagonalizing_gates(self, num_qubits: Optional[int] = None) -> Tuple[GateOperation, ...]:
+        if self._targets is None:
+            return tuple(Hadamard._diagonalizing_gate([target]) for target in range(num_qubits))
+        return (Hadamard._diagonalizing_gate(self._targets),)
+
+    @staticmethod
+    def _diagonalizing_gate(targets):
+        return gate_operations.RotY(targets, -math.pi / 4)
 
 
 class PauliX(Observable):
@@ -115,10 +116,14 @@ class PauliX(Observable):
     def eigenvalues(self) -> np.ndarray:
         return pauli_eigenvalues(1)
 
-    @property
-    def diagonalizing_matrix(self) -> Optional[np.ndarray]:
-        # H
-        return np.array([[1, 1], [1, -1]]) / math.sqrt(2)
+    def diagonalizing_gates(self, num_qubits: Optional[int] = None) -> Tuple[GateOperation, ...]:
+        if self._targets is None:
+            return tuple(PauliX._diagonalizing_gate([target]) for target in range(num_qubits))
+        return (PauliX._diagonalizing_gate(self._targets),)
+
+    @staticmethod
+    def _diagonalizing_gate(targets):
+        return gate_operations.Hadamard(targets)
 
 
 class PauliY(Observable):
@@ -130,6 +135,9 @@ class PauliY(Observable):
         as a Hermitian operator to be measured, while the gate is viewed as a unitary
         operator to evolve the state of the system.
     """
+
+    # HS^{\dagger}
+    _diagonalizing_matrix = np.array([[1, -1j], [1, 1j]]) / math.sqrt(2)
 
     def __init__(self, targets: Optional[List[int]] = None):
         self._targets = _validate_and_clone_single_qubit_target(targets)
@@ -146,10 +154,14 @@ class PauliY(Observable):
     def eigenvalues(self) -> np.ndarray:
         return pauli_eigenvalues(1)
 
-    @property
-    def diagonalizing_matrix(self) -> Optional[np.ndarray]:
-        # HS^{\dagger}
-        return np.array([[1, -1j], [1, 1j]]) / math.sqrt(2)
+    def diagonalizing_gates(self, num_qubits: Optional[int] = None) -> Tuple[GateOperation, ...]:
+        if self._targets is None:
+            return tuple(PauliY._diagonalizing_gate([target]) for target in range(num_qubits))
+        return (PauliY._diagonalizing_gate(self._targets),)
+
+    @staticmethod
+    def _diagonalizing_gate(targets):
+        return gate_operations.Unitary(targets, PauliY._diagonalizing_matrix)
 
 
 class PauliZ(Observable):
@@ -181,9 +193,9 @@ class PauliZ(Observable):
     def eigenvalues(self) -> np.ndarray:
         return pauli_eigenvalues(1)
 
-    @property
-    def diagonalizing_matrix(self) -> Optional[np.ndarray]:
-        return None
+    def diagonalizing_gates(self, num_qubits: Optional[int] = None) -> Tuple[GateOperation, ...]:
+        # Already diagonalized
+        return ()
 
 
 class Hermitian(Observable):
@@ -203,6 +215,9 @@ class Hermitian(Observable):
             )
         check_hermitian(clone)
         self._matrix = clone
+        eigendecomposition = Hermitian._eigendecomposition(clone)
+        self._eigenvalues = eigendecomposition["eigenvalues"]
+        self._diagonalizing_matrix = eigendecomposition["eigenvectors"].conj().T
 
     @property
     def matrix(self) -> np.ndarray:
@@ -215,18 +230,26 @@ class Hermitian(Observable):
 
     @property
     def eigenvalues(self) -> np.ndarray:
-        return self._eigendecomposition()["eigenvalues"]
+        return self._eigenvalues
 
-    @property
-    def diagonalizing_matrix(self) -> Optional[np.ndarray]:
-        return self._eigendecomposition()["eigenvectors"].conj().T
+    def diagonalizing_gates(self, num_qubits: Optional[int] = None) -> Tuple[GateOperation, ...]:
+        if self._targets is None:
+            return tuple(self._diagonalizing_gate([target]) for target in range(num_qubits))
+        return (self._diagonalizing_gate(self._targets),)
 
-    def _eigendecomposition(self) -> Dict[str, np.ndarray]:
+    def _diagonalizing_gate(self, targets):
+        return gate_operations.Unitary(targets, self._diagonalizing_matrix)
+
+    @staticmethod
+    def _eigendecomposition(matrix: np.ndarray) -> Dict[str, np.ndarray]:
         """Decomposes the Hermitian matrix into its eigenvectors and associated eigenvalues.
 
         The eigendecomposition is cached so that if another Hermitian observable
         is created with the same matrix, the eigendecomposition doesn't have to
         be recalculated.
+
+        Args:
+            matrix (np.ndarray): The matrix to decompose
 
         Returns:
             Dict[str, np.ndarray]: The keys are "eigenvectors", mapping to a matrix whose
@@ -234,9 +257,9 @@ class Hermitian(Observable):
             associated eigenvalues in the order their corresponding eigenvectors in the
             "eigenvectors" matrix
         """
-        mat_key = tuple(self._matrix.flatten().tolist())
+        mat_key = tuple(matrix.flatten().tolist())
         if mat_key not in Hermitian._eigenpairs:
-            eigenvalues, eigenvectors = np.linalg.eigh(self.matrix)
+            eigenvalues, eigenvectors = np.linalg.eigh(matrix)
             Hermitian._eigenpairs[mat_key] = {
                 "eigenvectors": eigenvectors,
                 "eigenvalues": eigenvalues,
@@ -261,9 +284,8 @@ class TensorProduct(Observable):
         self._measured_qubits = tuple(
             qubit for observable in factors for qubit in observable.measured_qubits
         )
-        self._diagonalizing_matrix = TensorProduct._construct_matrix(factors)
         self._eigenvalues = TensorProduct._compute_eigenvalues(factors, self._measured_qubits)
-        self._factors = factors
+        self._factors = tuple(factors)
 
     @property
     def factors(self) -> Tuple[Observable]:
@@ -281,20 +303,8 @@ class TensorProduct(Observable):
     def eigenvalues(self) -> np.ndarray:
         return self._eigenvalues
 
-    @property
-    def diagonalizing_matrix(self) -> Optional[np.ndarray]:
-        return self._diagonalizing_matrix
-
-    @staticmethod
-    def _construct_matrix(factors: List[Observable]) -> Optional[np.ndarray]:
-        matrices = tuple(
-            factor.diagonalizing_matrix
-            for factor in factors
-            # Ignore observables with trivial diagonalizing matrices
-            if factor.diagonalizing_matrix is not None
-        )
-        # (A \otimes I)(I \otimes B) == A \otimes B
-        return functools.reduce(np.kron, matrices) if matrices else None
+    def diagonalizing_gates(self, num_qubits: Optional[int] = None) -> Tuple[GateOperation, ...]:
+        return sum((factor.diagonalizing_gates() for factor in self._factors), ())
 
     @staticmethod
     def _compute_eigenvalues(factors: List[Observable], qubits: Tuple[int, ...]) -> np.ndarray:

--- a/src/braket/default_simulator/operation.py
+++ b/src/braket/default_simulator/operation.py
@@ -78,10 +78,18 @@ class Observable(Operation, ABC):
         np.ndarray: The eigenvalues of the observable ordered by computational basis state.
         """
 
-    @property
     @abstractmethod
-    def diagonalizing_matrix(self) -> Optional[np.ndarray]:
-        """
-        Optional[np.ndarray]: The matrix that diagonalizes the observable
-        in the computational basis if it is not already in the computational basis.
+    def diagonalizing_gates(self, num_qubits: Optional[int] = None) -> Tuple[GateOperation, ...]:
+        """The gates that diagonalize the observable in the computational basis.
+
+        Args:
+            num_qubits (int, optional): The number of qubits the observable acts on.
+                Only used if no target is specified, in which case a gate is created
+                for each target qubit. This only makes sense for single-qubit observables.
+
+        Returns:
+            Tuple[GateOperation, ...]: The gates that diagonalize the observable in the
+            computational basis, if it is not already in the computational basis.
+            If there is no explicit target, this method returns a tuple of gates
+            acting on every qubit.
         """

--- a/src/braket/default_simulator/operation_helpers.py
+++ b/src/braket/default_simulator/operation_helpers.py
@@ -11,12 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from functools import lru_cache, singledispatch
-from typing import List, Optional, Tuple
+from functools import lru_cache
+from typing import List, Tuple
 
 import numpy as np
-
-from braket.default_simulator.operation import GateOperation, Observable
 
 
 @lru_cache()
@@ -90,33 +88,3 @@ def check_hermitian(matrix: np.ndarray):
     """
     if not np.allclose(matrix, matrix.T.conj()):
         raise ValueError(f"{matrix} is not Hermitian")
-
-
-def get_matrix(operation) -> Optional[np.ndarray]:
-    """Gets the matrix of the given operation.
-
-    For a `GateOperation`, this is the gate's unitary matrix, and for an `Observable`,
-    this is its diagonalizing matrix.
-
-    Args:
-        operation: The operation whose matrix is needed
-
-    Returns:
-        np.ndarray: The matrix of the operation
-    """
-    return _get_matrix(operation)
-
-
-@singledispatch
-def _get_matrix(operation):
-    raise ValueError(f"Unrecognized operation: {operation}")
-
-
-@_get_matrix.register
-def _(gate: GateOperation):
-    return gate.matrix
-
-
-@_get_matrix.register
-def _(observable: Observable):
-    return observable.diagonalizing_matrix

--- a/src/braket/default_simulator/simulation.py
+++ b/src/braket/default_simulator/simulation.py
@@ -15,7 +15,7 @@ from typing import List
 
 import numpy as np
 
-from braket.default_simulator.operation import GateOperation, Observable, Operation
+from braket.default_simulator.operation import GateOperation, Observable
 from braket.default_simulator.simulation_strategies import (
     batch_operation_strategy,
     single_operation_strategy,
@@ -94,13 +94,19 @@ class StateVectorSimulation:
         """
         if self._post_observables is not None:
             raise RuntimeError("Observables have already been applied.")
+        operations = list(
+            sum(
+                [observable.diagonalizing_gates(self._qubit_count) for observable in observables],
+                (),
+            )
+        )
         self._post_observables = StateVectorSimulation._apply_operations(
-            self._state_vector, self._qubit_count, observables, self._batch_size
+            self._state_vector, self._qubit_count, operations, self._batch_size
         )
 
     @staticmethod
     def _apply_operations(
-        state: np.ndarray, qubit_count: int, operations: List[Operation], batch_size: int
+        state: np.ndarray, qubit_count: int, operations: List[GateOperation], batch_size: int
     ) -> np.ndarray:
         state_tensor = np.reshape(state, [2] * qubit_count)
         final = (

--- a/src/braket/default_simulator/simulation_strategies/single_operation_strategy.py
+++ b/src/braket/default_simulator/simulation_strategies/single_operation_strategy.py
@@ -15,12 +15,11 @@ from typing import List, Tuple
 
 import numpy as np
 
-from braket.default_simulator.operation import Operation
-from braket.default_simulator.operation_helpers import get_matrix
+from braket.default_simulator.operation import GateOperation
 
 
 def apply_operations(
-    state: np.ndarray, qubit_count: int, operations: List[Operation]
+    state: np.ndarray, qubit_count: int, operations: List[GateOperation]
 ) -> np.ndarray:
     """Applies operations to a state vector one at a time.
 
@@ -28,22 +27,16 @@ def apply_operations(
         state (np.ndarray): The state vector to apply the given operations to, as a type
             (num_qubits, 0) tensor
         qubit_count (int): The number of qubits in the state
-        operations (List[Operation]): The operations to apply to the state vector
+        operations (List[GateOperation]): The operations to apply to the state vector
 
     Returns:
         np.ndarray: The state vector after applying the given operations, as a type
         (qubit_count, 0) tensor
     """
     for operation in operations:
-        matrix = get_matrix(operation)
+        matrix = operation.matrix
         targets = operation.targets
-        # `operation` is ignored if it acts trivially on its targets
-        if targets:
-            state = _apply_operation(state, qubit_count, matrix, targets)
-        elif targets is None:
-            # `operation` is an observable, and the only element in `operations`
-            for qubit in range(qubit_count):
-                state = _apply_operation(state, qubit_count, matrix, (qubit,))
+        state = _apply_operation(state, qubit_count, matrix, targets)
     return state
 
 

--- a/test/unit_tests/braket/default_simulator/test_gate_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_gate_operations.py
@@ -74,16 +74,12 @@ testdata = [
 ]
 
 
-@pytest.mark.parametrize("instruction, targets, operation_type", testdata)
-def test_gate_operation_matrix_is_unitary(instruction, targets, operation_type):
-    check_unitary(gate_operations.from_braket_instruction(instruction).matrix)
-
-
-@pytest.mark.parametrize("instruction, targets, operation_type", testdata)
-def test_from_braket_instruction(instruction, targets, operation_type):
-    operation_instance = gate_operations.from_braket_instruction(instruction)
+@pytest.mark.parametrize("ir_instruction, targets, operation_type", testdata)
+def test_gate_operation(ir_instruction, targets, operation_type):
+    operation_instance = gate_operations.from_braket_instruction(ir_instruction)
     assert isinstance(operation_instance, operation_type)
     assert operation_instance.targets == targets
+    check_unitary(operation_instance.matrix)
 
 
 @pytest.mark.xfail(raises=ValueError)

--- a/test/unit_tests/braket/default_simulator/test_observables.py
+++ b/test/unit_tests/braket/default_simulator/test_observables.py
@@ -68,8 +68,8 @@ y_diag = np.array([[1, -1j], [1, 1j]]) / np.sqrt(2)
 def test_observable_properties_single_qubit(
     obs_class, extra_args, expected_gates, eigenvalues, is_standard
 ):
-    num_qubits = np.random.randint(1, 100)
-    measured_qubits = (np.random.randint(0, num_qubits),)
+    num_qubits = 50
+    measured_qubits = (20,)
     observable = obs_class(*extra_args, targets=list(measured_qubits))
     actual_gates = observable.diagonalizing_gates(num_qubits)
     for gate in actual_gates:
@@ -89,7 +89,7 @@ def test_observable_properties_single_qubit(
 def test_observable_properties_all_qubits(
     obs_class, extra_args, expected_gates, eigenvalues, is_standard
 ):
-    num_qubits = np.random.randint(1, 10)  # Smaller number so tests run faster
+    num_qubits = 10  # Smaller number so tests run faster
     observable = obs_class(*extra_args)
     actual_gates = observable.diagonalizing_gates(num_qubits)
     for gate in actual_gates:

--- a/test/unit_tests/braket/default_simulator/test_operation_helpers.py
+++ b/test/unit_tests/braket/default_simulator/test_operation_helpers.py
@@ -22,7 +22,6 @@ from braket.default_simulator.operation_helpers import (
     check_hermitian,
     check_matrix_dimensions,
     check_unitary,
-    get_matrix,
     ir_matrix_to_ndarray,
 )
 
@@ -138,17 +137,3 @@ def test_check_unitary_invalid_matrix(matrix):
 @pytest.mark.parametrize("matrix", invalid_hermitian_matrices)
 def test_check_hermitian_invalid_matrix(matrix):
     check_hermitian(matrix)
-
-
-@pytest.mark.parametrize("operation", gate_testdata)
-def test_get_matrix_gate_operation(operation):
-    assert np.allclose(get_matrix(operation), operation.matrix)
-
-
-@pytest.mark.parametrize("operation", observable_testdata)
-def test_get_matrix_observable(operation):
-    matrix = get_matrix(operation)
-    if matrix is not None:
-        assert np.allclose(matrix, operation.diagonalizing_matrix)
-    else:
-        assert operation.diagonalizing_matrix is None

--- a/test/unit_tests/braket/default_simulator/test_simulation.py
+++ b/test/unit_tests/braket/default_simulator/test_simulation.py
@@ -247,13 +247,6 @@ def test_state_with_observables_fails_before_applying(batch_size):
 
 
 @pytest.mark.parametrize("batch_size", [1, 5, 10])
-@pytest.mark.xfail(raises=ValueError)
-def test_build_contraction_fails_unrecognised_operation(batch_size):
-    simulation = StateVectorSimulation(4, 0, batch_size)
-    simulation.evolve([gate_operations.PauliX([0]), "foo"])
-
-
-@pytest.mark.parametrize("batch_size", [1, 5, 10])
 def test_simulation_qft_circuit(qft_circuit_operations, batch_size):
     qubit_count = 16
     simulation = StateVectorSimulation(qubit_count, 0, batch_size)


### PR DESCRIPTION
Currently, the simulator calculates the entire matrix of a tensor product observable before applying it, which is extremely inefficient. This change applies the diagonalizing gates of the factors individually.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
