### PR TITLE
feature: adding two qubit Pauli channels

### DIFF
--- a/src/braket/default_simulator/density_matrix_simulation.py
+++ b/src/braket/default_simulator/density_matrix_simulation.py
@@ -36,7 +36,7 @@ class DensityMatrixSimulation(Simulation):
                 or expectation, are generated.
         """
         super().__init__(qubit_count=qubit_count, shots=shots)
-        initial_state = np.zeros((2 ** qubit_count, 2 ** qubit_count), dtype=complex)
+        initial_state = np.zeros((2**qubit_count, 2**qubit_count), dtype=complex)
         initial_state[0, 0] = 1
         self._density_matrix = initial_state
         self._post_observables = None
@@ -105,7 +105,7 @@ class DensityMatrixSimulation(Simulation):
                     dm_tensor, qubit_count, operation.matrices, targets
                 )
 
-        return np.reshape(dm_tensor, (2 ** qubit_count, 2 ** qubit_count))
+        return np.reshape(dm_tensor, (2**qubit_count, 2**qubit_count))
 
     def retrieve_samples(self) -> List[int]:
         return np.random.choice(

--- a/src/braket/default_simulator/density_matrix_simulator.py
+++ b/src/braket/default_simulator/density_matrix_simulator.py
@@ -71,6 +71,7 @@ class DensityMatrixSimulator(BaseLocalSimulator):
                             "iswap",
                             "kraus",
                             "pauli_channel",
+                            "two_qubit_pauli_channel",
                             "phase_flip",
                             "phase_damping",
                             "phaseshift",

--- a/src/braket/default_simulator/noise_operations.py
+++ b/src/braket/default_simulator/noise_operations.py
@@ -342,5 +342,5 @@ class TwoQubitPauliChannel(KrausOperation):
 
 
 @_from_braket_instruction.register(braket_instruction.MultiQubitPauliChannel)
-def _two_qubit_pauli_channel(instruction) -> MultiQubitPauliChannel:
-    return MultiQubitPauliChannel(instruction.targets, instruction.probabilities)
+def _two_qubit_pauli_channel(instruction) -> TwoQubitPauliChannel:
+    return TwoQubitPauliChannel(instruction.targets, instruction.probabilities)

--- a/src/braket/default_simulator/noise_operations.py
+++ b/src/braket/default_simulator/noise_operations.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+import itertools
 from typing import List, Tuple
 
 import braket.ir.jaqcd as braket_instruction
@@ -300,3 +301,46 @@ def _kraus(instruction) -> Kraus:
     return Kraus(
         instruction.targets, [ir_matrix_to_ndarray(matrix) for matrix in instruction.matrices]
     )
+
+
+class TwoQubitPauliChannel(KrausOperation):
+    """Two qubit Pauli noise channel"""
+
+    _paulis = {
+        "I": np.array([[1.0, 0.0], [0.0, 1.0]], dtype=complex),
+        "X": np.array([[0.0, 1.0], [1.0, 0.0]], dtype=complex),
+        "Y": np.array([[0.0, -1.0j], [1.0j, 0.0]], dtype=complex),
+        "Z": np.array([[1.0, 0.0], [0.0, -1.0]], dtype=complex),
+    }
+    _tensor_products_strings = itertools.product(_paulis.keys(), repeat=2)
+    _names_list = ["".join(x) for x in _tensor_products_strings]
+
+    def __init__(self, targets, probabilities):
+        self._targets = tuple(targets)
+        self.probabilities = probabilities
+
+        total_prob = sum(self.probabilities.values())
+
+        K_list = [np.sqrt(1 - total_prob) * np.identity(4)]  # identity
+        for pstring in self._names_list[1:]:  # ignore "II"
+            if pstring in self.probabilities:
+                mat = np.sqrt(self.probabilities[pstring]) * np.kron(
+                    self._paulis[pstring[0]], self._paulis[pstring[1]]
+                )
+                K_list.append(mat)
+            else:
+                K_list.append(np.zeros((4, 4)))
+        self._matrices = K_list
+
+    @property
+    def matrices(self) -> List[np.ndarray]:
+        return self._matrices
+
+    @property
+    def targets(self) -> Tuple[int, ...]:
+        return self._targets
+
+
+@_from_braket_instruction.register(braket_instruction.MultiQubitPauliChannel)
+def _two_qubit_pauli_channel(instruction) -> MultiQubitPauliChannel:
+    return MultiQubitPauliChannel(instruction.targets, instruction.probabilities)

--- a/src/braket/default_simulator/observables.py
+++ b/src/braket/default_simulator/observables.py
@@ -343,7 +343,7 @@ class TensorProduct(Observable):
         self._factors = tuple(factors)
 
     def _pow(self, power: int) -> Observable:
-        return TensorProduct([factor ** power for factor in self._factors])
+        return TensorProduct([factor**power for factor in self._factors])
 
     @property
     def factors(self) -> Tuple[Observable]:

--- a/src/braket/default_simulator/result_types.py
+++ b/src/braket/default_simulator/result_types.py
@@ -314,7 +314,7 @@ class Variance(ObservableResultType):
 
     @staticmethod
     def _calculate_single_quantity(simulation: Simulation, observable: Observable) -> float:
-        return simulation.expectation(observable ** 2) - simulation.expectation(observable) ** 2
+        return simulation.expectation(observable**2) - simulation.expectation(observable) ** 2
 
 
 @_from_braket_result_type.register

--- a/src/braket/default_simulator/simulator.py
+++ b/src/braket/default_simulator/simulator.py
@@ -45,6 +45,7 @@ _NOISE_INSTRUCTIONS = frozenset(
         "generalized_amplitude_damping",
         "kraus",
         "pauli_channel",
+        "two_qubit_pauli_channel",
         "phase_flip",
         "phase_damping",
         "two_qubit_dephasing",

--- a/src/braket/default_simulator/state_vector_simulation.py
+++ b/src/braket/default_simulator/state_vector_simulation.py
@@ -59,7 +59,7 @@ class StateVectorSimulation(Simulation):
             raise ValueError(f"batch_size must be a positive integer, but {batch_size} provided")
 
         super().__init__(qubit_count=qubit_count, shots=shots)
-        initial_state = np.zeros(2 ** qubit_count, dtype=complex)
+        initial_state = np.zeros(2**qubit_count, dtype=complex)
         initial_state[0] = 1
         self._state_vector = initial_state
         self._batch_size = batch_size
@@ -106,7 +106,7 @@ class StateVectorSimulation(Simulation):
                 state_tensor, qubit_count, operations, batch_size
             )
         )
-        return np.reshape(final, 2 ** qubit_count)
+        return np.reshape(final, 2**qubit_count)
 
     def retrieve_samples(self) -> List[int]:
         return np.random.choice(len(self._state_vector), p=self.probabilities, size=self._shots)
@@ -144,7 +144,7 @@ class StateVectorSimulation(Simulation):
         qubit_count = self._qubit_count
         with_observables = observable.apply(np.reshape(self._state_vector, [2] * qubit_count))
         return complex(
-            np.dot(self._state_vector.conj(), np.reshape(with_observables, 2 ** qubit_count))
+            np.dot(self._state_vector.conj(), np.reshape(with_observables, 2**qubit_count))
         ).real
 
     @property

--- a/test/unit_tests/braket/default_simulator/test_density_matrix_simulation.py
+++ b/test/unit_tests/braket/default_simulator/test_density_matrix_simulation.py
@@ -211,7 +211,7 @@ def test_simulation_qft_circuit(qft_circuit_operations):
     simulation = DensityMatrixSimulation(qubit_count, 0)
     operations = qft_circuit_operations(qubit_count)
     simulation.evolve(operations)
-    assert np.allclose(simulation.probabilities, [1 / (2 ** qubit_count)] * (2 ** qubit_count))
+    assert np.allclose(simulation.probabilities, [1 / (2**qubit_count)] * (2**qubit_count))
 
 
 def test_simulation_retrieve_samples():

--- a/test/unit_tests/braket/default_simulator/test_density_matrix_simulator.py
+++ b/test/unit_tests/braket/default_simulator/test_density_matrix_simulator.py
@@ -369,6 +369,7 @@ def test_properties():
                         "iswap",
                         "kraus",
                         "pauli_channel",
+                        "two_qubit_pauli_channel",
                         "phase_flip",
                         "phase_damping",
                         "phaseshift",

--- a/test/unit_tests/braket/default_simulator/test_noise_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_noise_operations.py
@@ -54,14 +54,14 @@ testdata = [
     ),
     (
         instruction.MultiQubitPauliChannel(
-            target=[0], probabilities={"X": 0.1, "Y": 0.2, "Z": 0.3}
+             targets=[0], probabilities={"X": 0.1, "Y": 0.2, "Z": 0.3}
         ),
         (5,),
         noise_operations.TwoQubitPauliChannel,
     ),
     (
         instruction.MultiQubitPauliChannel(
-            target=[0, 1], probabilities={"XX": 0.01, "YY": 0.02, "XZ": 0.03}
+            targets=[0, 1], probabilities={"XX": 0.01, "YY": 0.02, "XZ": 0.03}
         ),
         (5,),
         noise_operations.TwoQubitPauliChannel,

--- a/test/unit_tests/braket/default_simulator/test_noise_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_noise_operations.py
@@ -52,6 +52,20 @@ testdata = [
         (5,),
         noise_operations.PauliChannel,
     ),
+    (
+        instruction.MultiQubitPauliChannel(
+            target=[0], probabilities={"X": 0.1, "Y": 0.2, "Z": 0.3}
+        ),
+        (5,),
+        noise_operations.TwoQubitPauliChannel,
+    ),
+    (
+        instruction.MultiQubitPauliChannel(
+            target=[0, 1], probabilities={"XX": 0.01, "YY": 0.02, "XZ": 0.03}
+        ),
+        (5,),
+        noise_operations.TwoQubitPauliChannel,
+    ),
     (instruction.PhaseDamping(target=0, gamma=0.89), (0,), noise_operations.PhaseDamping),
     (
         instruction.Kraus(

--- a/test/unit_tests/braket/default_simulator/test_noise_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_noise_operations.py
@@ -54,7 +54,7 @@ testdata = [
     ),
     (
         instruction.MultiQubitPauliChannel(
-             targets=[0], probabilities={"X": 0.1, "Y": 0.2, "Z": 0.3}
+            targets=[0], probabilities={"X": 0.1, "Y": 0.2, "Z": 0.3}
         ),
         (5,),
         noise_operations.TwoQubitPauliChannel,

--- a/test/unit_tests/braket/default_simulator/test_noise_operations.py
+++ b/test/unit_tests/braket/default_simulator/test_noise_operations.py
@@ -54,16 +54,9 @@ testdata = [
     ),
     (
         instruction.MultiQubitPauliChannel(
-            targets=[0], probabilities={"X": 0.1, "Y": 0.2, "Z": 0.3}
+            targets=[5, 6], probabilities={"XX": 0.01, "YY": 0.02, "XZ": 0.03}
         ),
-        (5,),
-        noise_operations.TwoQubitPauliChannel,
-    ),
-    (
-        instruction.MultiQubitPauliChannel(
-            targets=[0, 1], probabilities={"XX": 0.01, "YY": 0.02, "XZ": 0.03}
-        ),
-        (5,),
+        (5, 6),
         noise_operations.TwoQubitPauliChannel,
     ),
     (instruction.PhaseDamping(target=0, gamma=0.89), (0,), noise_operations.PhaseDamping),

--- a/test/unit_tests/braket/default_simulator/test_observables.py
+++ b/test/unit_tests/braket/default_simulator/test_observables.py
@@ -110,9 +110,9 @@ def test_observable_properties_all_qubits(
 @pytest.mark.parametrize("obs", involutory)
 def test_involutory_powers(obs):
     for power in range(0, 10, 2):
-        assert (obs ** power).__class__ is observables.Identity
+        assert (obs**power).__class__ is observables.Identity
     for power in range(1, 11, 2):
-        assert (obs ** power).__class__ is obs.__class__
+        assert (obs**power).__class__ is obs.__class__
 
 
 @pytest.mark.xfail(raises=TypeError)

--- a/test/unit_tests/braket/default_simulator/test_result_types.py
+++ b/test/unit_tests/braket/default_simulator/test_result_types.py
@@ -222,7 +222,7 @@ def test_variance_no_targets(state_vector, obs):
 
 def _variance_from_diagonalization(diagonalized_probs, qubits, eigenvalues):
     marginal = marginal_probability(diagonalized_probs, qubits)
-    return marginal @ (eigenvalues.real ** 2) - (marginal @ eigenvalues).real ** 2
+    return marginal @ (eigenvalues.real**2) - (marginal @ eigenvalues).real ** 2
 
 
 def test_from_braket_result_type_statevector():

--- a/test/unit_tests/braket/default_simulator/test_state_vector_simulation.py
+++ b/test/unit_tests/braket/default_simulator/test_state_vector_simulation.py
@@ -252,7 +252,7 @@ def test_simulation_qft_circuit(qft_circuit_operations, batch_size):
     simulation = StateVectorSimulation(qubit_count, 0, batch_size)
     operations = qft_circuit_operations(qubit_count)
     simulation.evolve(operations)
-    assert np.allclose(simulation.probabilities, [1 / (2 ** qubit_count)] * (2 ** qubit_count))
+    assert np.allclose(simulation.probabilities, [1 / (2**qubit_count)] * (2**qubit_count))
 
 
 @pytest.mark.parametrize("batch_size", [1, 5, 10])

--- a/test/unit_tests/braket/default_simulator/test_state_vector_simulator.py
+++ b/test/unit_tests/braket/default_simulator/test_state_vector_simulator.py
@@ -322,7 +322,7 @@ def test_simulator_bell_pair_result_types(bell_ir_with_result, targets, batch_si
     result = simulator.run(ir, qubit_count=2, shots=0, batch_size=batch_size)
     assert len(result.resultTypes) == 2
     assert result.resultTypes[0] == ResultTypeValue.construct(
-        type=ir.results[0], value={"11": complex(1 / 2 ** 0.5)}
+        type=ir.results[0], value={"11": complex(1 / 2**0.5)}
     )
     assert result.resultTypes[1] == ResultTypeValue.construct(
         type=ir.results[1], value=(0 if targets else [0, 0])


### PR DESCRIPTION
*Description of changes:*
Adding support for two-qubit Pauli channel noise in the local simulator. 

*Testing done:*
Adding two-qubit Pauli channel to existing tests. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
