### PR TITLE
feature: warning when using advanced language features

### DIFF
--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -157,7 +157,6 @@ class Interpreter:
 
     @visit.register
     def _(self, node: ClassicalDeclaration) -> None:
-        self._uses_advanced_language_features = True
         node_type = self.visit(node.type)
         if node.init_expression is not None:
             init_expression = self.visit(node.init_expression)
@@ -455,7 +454,6 @@ class Interpreter:
 
     @visit.register
     def _(self, node: ClassicalAssignment) -> None:
-        self._uses_advanced_language_features = True
         lvalue_name = get_identifier_name(node.lvalue)
         if self.context.get_const(lvalue_name):
             raise TypeError(f"Cannot update const value {lvalue_name}")

--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -122,8 +122,10 @@ class Interpreter:
         self.visit(program)
         if self._uses_advanced_language_features:
             self.logger.warning(
-                "This program uses OpenQASM language features that are "
-                "currently only supported in the LocalSimulator"
+                "This program uses OpenQASM language features "
+                "only supported in the LocalSimulator. Some of "
+                "these features may not be supported on QPU or "
+                "managed simulator."
             )
         return self.context.circuit
 

--- a/src/braket/default_simulator/openqasm/program_context.py
+++ b/src/braket/default_simulator/openqasm/program_context.py
@@ -126,6 +126,10 @@ class ScopedTable(Table):
         self._scopes.pop()
 
     @property
+    def in_global_scope(self):
+        return len(self._scopes) == 1
+
+    @property
     def current_scope(self) -> Dict[str, Any]:
         return self._scopes[-1]
 
@@ -442,6 +446,10 @@ class ProgramContext:
         self.symbol_table.pop_scope()
         self.variable_table.pop_scope()
         self.gate_table.pop_scope()
+
+    @property
+    def in_global_scope(self):
+        return self.symbol_table.in_global_scope
 
     def get_type(self, name: str) -> Union[ClassicalType, Type[LiteralType]]:
         """Get symbol type by name"""

--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -1615,3 +1615,35 @@ def test_noise():
             ],
         ),
     ]
+
+
+@pytest.mark.parametrize(
+    "qasm",
+    (
+        "int x;",
+        "int x = 1;",
+        "int x; x = 1;",
+        "input int x;",
+        "const int x = 4;",
+        "int x = 1 + 1;",
+        "qubit[2] q; h q[0:1];",
+        "gate my_x q { x q; }",
+        "qubit q; gphase(.3);",
+        "qubit[2] q; ctrl @ x q[0], q[1];",
+        "qubit q; if (1) { x q; }",
+        "qubit q; for int i in [0:10] { x q; }",
+        "while (false) {}",
+        "def subroutine() {}",
+        "def subroutine() {} subroutine();",
+    ),
+)
+def test_advanced_language_features(qasm, caplog):
+    Interpreter().run(qasm, inputs={"x": 1})
+    assert re.match(
+        (
+            "WARNING.*"
+            "This program uses OpenQASM language features that are "
+            "currently only supported in the LocalSimulator\n"
+        ),
+        caplog.text,
+    )

--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -1639,8 +1639,10 @@ def test_advanced_language_features(qasm, caplog):
     assert re.match(
         (
             "WARNING.*"
-            "This program uses OpenQASM language features that are "
-            "currently only supported in the LocalSimulator\n"
+            "This program uses OpenQASM language features "
+            "only supported in the LocalSimulator\. Some of "
+            "these features may not be supported on QPU or "
+            "managed simulator\.\n"
         ),
         caplog.text,
     )

--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -1620,9 +1620,6 @@ def test_noise():
 @pytest.mark.parametrize(
     "qasm",
     (
-        "int x;",
-        "int x = 1;",
-        "int x; x = 1;",
         "input int x;",
         "const int x = 4;",
         "int x = 1 + 1;",

--- a/test/unit_tests/braket/default_simulator/test_density_matrix_simulator.py
+++ b/test/unit_tests/braket/default_simulator/test_density_matrix_simulator.py
@@ -88,7 +88,7 @@ def bell_ir(ir_type):
     )
 
 
-def test_simulator_run_noisy_circuit(noisy_circuit_2_qubit):
+def test_simulator_run_noisy_circuit(noisy_circuit_2_qubit, caplog):
     simulator = DensityMatrixSimulator()
     shots_count = 10000
     if isinstance(noisy_circuit_2_qubit, JaqcdProgram):
@@ -106,9 +106,10 @@ def test_simulator_run_noisy_circuit(noisy_circuit_2_qubit):
         id=result.taskMetadata.id, deviceId=DensityMatrixSimulator.DEVICE_ID, shots=shots_count
     )
     assert result.additionalMetadata == AdditionalMetadata(action=noisy_circuit_2_qubit)
+    assert not caplog.text
 
 
-def test_simulator_run_bell_pair(bell_ir):
+def test_simulator_run_bell_pair(bell_ir, caplog):
     simulator = DensityMatrixSimulator()
     shots_count = 10000
     if isinstance(bell_ir, JaqcdProgram):
@@ -126,6 +127,7 @@ def test_simulator_run_bell_pair(bell_ir):
         id=result.taskMetadata.id, deviceId=DensityMatrixSimulator.DEVICE_ID, shots=shots_count
     )
     assert result.additionalMetadata == AdditionalMetadata(action=bell_ir)
+    assert not caplog.text
 
 
 @pytest.mark.xfail(raises=ValueError)
@@ -460,7 +462,7 @@ def test_simulator_run_densitymatrix_shots():
         simulator.run(qasm, shots=100)
 
 
-def test_simulator_run_result_types_shots():
+def test_simulator_run_result_types_shots(caplog):
     simulator = DensityMatrixSimulator()
     jaqcd = JaqcdProgram.parse_raw(
         json.dumps(
@@ -489,9 +491,10 @@ def test_simulator_run_result_types_shots():
         assert len(result.measurements) == shots_count
         assert result.measuredQubits == [0, 1]
     assert not jaqcd_result.resultTypes
+    assert not caplog.text
 
 
-def test_simulator_run_result_types_shots_basis_rotation_gates():
+def test_simulator_run_result_types_shots_basis_rotation_gates(caplog):
     simulator = DensityMatrixSimulator()
     jaqcd = JaqcdProgram.parse_raw(
         json.dumps(
@@ -521,6 +524,7 @@ def test_simulator_run_result_types_shots_basis_rotation_gates():
         assert len(result.measurements) == shots_count
         assert result.measuredQubits == [0, 1]
     assert not jaqcd_result.resultTypes
+    assert not caplog.text
 
 
 @pytest.mark.xfail(raises=ValueError)
@@ -543,7 +547,7 @@ def test_simulator_run_result_types_shots_basis_rotation_gates_value_error():
 
 
 @pytest.mark.parametrize("targets", [(None), ([1]), ([0])])
-def test_simulator_bell_pair_result_types(bell_ir_with_result, targets):
+def test_simulator_bell_pair_result_types(bell_ir_with_result, targets, caplog):
     simulator = DensityMatrixSimulator()
     ir = bell_ir_with_result(targets)
     if isinstance(ir, JaqcdProgram):
@@ -558,6 +562,7 @@ def test_simulator_bell_pair_result_types(bell_ir_with_result, targets):
         id=result.taskMetadata.id, deviceId=DensityMatrixSimulator.DEVICE_ID, shots=0
     )
     assert result.additionalMetadata == AdditionalMetadata(action=ir)
+    assert not caplog.text
 
 
 def test_simulator_fails_samples_0_shots():
@@ -703,7 +708,7 @@ def test_simulator_valid_observables(result_types, expected):
         ),
     ],
 )
-def test_simulator_valid_observables_qasm(result_types, expected):
+def test_simulator_valid_observables_qasm(result_types, expected, caplog):
     simulator = DensityMatrixSimulator()
     prog = OpenQASMProgram(
         source=f"""
@@ -716,3 +721,4 @@ def test_simulator_valid_observables_qasm(result_types, expected):
     result = simulator.run(prog, shots=0)
     for i in range(len(result_types.split("\n")) - 2):
         assert np.allclose(result.resultTypes[i].value, expected[i])
+    assert not caplog.text


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Log a warning when user is using OpenQASM features that are only supported in the local sim

*Testing done:*

unit testing to make sure warnings are displayed when using advanced features and NOT DISPLAYED when not.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
