### PR TITLE
fix: no warning for binary expression in gate def

### DIFF
--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -193,7 +193,8 @@ class Interpreter:
 
     @visit.register
     def _(self, node: BinaryExpression) -> Union[BinaryExpression, LiteralType]:
-        self._uses_advanced_language_features = True
+        if self.context.in_global_scope:
+            self._uses_advanced_language_features = True
         lhs = self.visit(node.lhs)
         rhs = self.visit(node.rhs)
         if is_literal(lhs) and is_literal(rhs):
@@ -428,7 +429,6 @@ class Interpreter:
 
     @visit.register
     def _(self, node: QuantumPhase) -> None:
-        self._uses_advanced_language_features = True
         node.argument = self.visit(node.argument)
         node.modifiers = self.visit(node.modifiers)
         if is_inverted(node):

--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -1636,7 +1636,6 @@ def test_noise():
         "int x = 1 + 1;",
         "qubit[2] q; h q[0:1];",
         "gate my_x q { x q; }",
-        "qubit q; gphase(.3);",
         "qubit[2] q; ctrl @ x q[0], q[1];",
         "qubit q; if (1) { x q; }",
         "qubit q; for int i in [0:10] { x q; }",
@@ -1657,3 +1656,12 @@ def test_advanced_language_features(qasm, caplog):
         ),
         caplog.text,
     )
+
+
+def test_no_warning(caplog):
+    qasm = """
+    qubit q;
+    rz(4.9164057364353715) q;
+    """
+    Interpreter().run(qasm)
+    assert not caplog.text


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Was raising a warning when encountering binary expressions in the builtin gate definitions-- too sensitive, added a clause to stop incorrect warnings from going off.

Also no warning for phase instruction, since it's already listed in device properties as an operation. And we run into the same issue with being referenced in the builtin gates.

*Testing done:*

Added a test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
