### PR TITLE
bugfix: Feature/neutral atom simulator empty site bug

### DIFF
--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_result_converter.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_result_converter.py
@@ -30,9 +30,16 @@ def convert_result(
     """
     measurements = []
 
-    for key, val in zip(configurations, dist):
-        post_sequence = list(key)
-        post_sequence = [0 if item == "r" else 1 for item in post_sequence]
+    pre_sequence_arr = np.array(pre_sequence)
+    non_empty_sites = np.where(pre_sequence_arr == 1)[0]
+
+    for configuration, count in zip(configurations, dist):
+        post_sequence = [0] * len(pre_sequence)
+        for site, state in zip(non_empty_sites, list(configuration)):
+            if state == "g":
+                post_sequence[site] = 1
+            elif state == "r":
+                post_sequence[site] = 0
 
         shot_measurement = AnalogHamiltonianSimulationShotMeasurement(
             shotMetadata=AnalogHamiltonianSimulationShotMetadata(shotStatus="Success"),
@@ -40,7 +47,7 @@ def convert_result(
                 preSequence=pre_sequence, postSequence=post_sequence
             ),
         )
-        measurements += [shot_measurement for _ in range(val)]
+        measurements += [shot_measurement for _ in range(count)]
 
     return AnalogHamiltonianSimulationTaskResult(
         taskMetadata=task_Metadata, measurements=measurements

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_result_converter.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_result_converter.py
@@ -38,7 +38,7 @@ def convert_result(
         for site, state in zip(non_empty_sites, list(configuration)):
             if state == "g":
                 post_sequence[site] = 1
-            elif state == "r":
+            else: # state == "r":
                 post_sequence[site] = 0
 
         shot_measurement = AnalogHamiltonianSimulationShotMeasurement(

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_result_converter.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_result_converter.py
@@ -38,7 +38,7 @@ def convert_result(
         for site, state in zip(non_empty_sites, list(configuration)):
             if state == "g":
                 post_sequence[site] = 1
-            else: # state == "r":
+            else:  # state == "r":
                 post_sequence[site] = 0
 
         shot_measurement = AnalogHamiltonianSimulationShotMeasurement(

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_convert_result.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_convert_result.py
@@ -46,9 +46,10 @@ def test_sample_state(para):
 
 
 @pytest.mark.parametrize(
-    "dist, preSequence, configurations, taskMetadata", [
+    "dist, preSequence, configurations, taskMetadata",
+    [
         (mock_dist, mock_preSequence, configurations_1, mock_taskMetadata),
-    ]
+    ],
 )
 def test_convert_result(dist, preSequence, configurations, taskMetadata):
     result = convert_result(dist, preSequence, configurations, taskMetadata)
@@ -77,23 +78,25 @@ def test_convert_result(dist, preSequence, configurations, taskMetadata):
 
     assert pytest.approx(result) == pytest.approx(trueresult)
 
+
 @pytest.mark.parametrize(
-    "dist, preSequence, configurations, taskMetadata, expected_postSequence", [
+    "dist, preSequence, configurations, taskMetadata, expected_postSequence",
+    [
         ([1, 0, 0, 0], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 1, 0]),
         ([0, 1, 0, 0], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 0, 0]),
         ([0, 0, 1, 0], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 1, 0]),
         ([0, 0, 0, 1], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 0, 0]),
-        
         ([1, 0, 0, 0], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 0, 0, 1]),
         ([0, 1, 0, 0], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 0, 0, 0]),
         ([0, 0, 1, 0], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 0, 0, 1]),
         ([0, 0, 0, 1], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 0, 0, 0]),
-
         ([1, 0], [0, 0, 0, 1], ["g", "r"], mock_taskMetadata, [0, 0, 0, 1]),
         ([0, 1], [0, 0, 0, 1], ["g", "r"], mock_taskMetadata, [0, 0, 0, 0]),
-    ]
+    ],
 )
-def test_convert_result_with_empty_sites(dist, preSequence, configurations, taskMetadata, expected_postSequence):
+def test_convert_result_with_empty_sites(
+    dist, preSequence, configurations, taskMetadata, expected_postSequence
+):
     result = convert_result(dist, preSequence, configurations, taskMetadata)
     postSequence = result.measurements[0].shotResult.postSequence
-    assert result.measurements[0].shotResult.postSequence == expected_postSequence
+    assert postSequence == expected_postSequence

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_convert_result.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_convert_result.py
@@ -84,7 +84,7 @@ def test_convert_result(dist, preSequence, configurations, taskMetadata):
         ([0, 0, 1, 0], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 1, 0]),
         ([0, 0, 0, 1], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 0, 0]),
         
-        ([1, 0, 0, 0], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 0, 0, 0]),
+        ([1, 0, 0, 0], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 0, 0, 1]),
         ([0, 1, 0, 0], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 0, 0, 0]),
         ([0, 0, 1, 0], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 0, 0, 1]),
         ([0, 0, 0, 1], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 0, 0, 0]),

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_convert_result.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_convert_result.py
@@ -46,10 +46,11 @@ def test_sample_state(para):
 
 
 @pytest.mark.parametrize(
-    "para", [[mock_dist, mock_preSequence, configurations_1, mock_taskMetadata]]
+    "dist, preSequence, configurations, taskMetadata", [
+        (mock_dist, mock_preSequence, configurations_1, mock_taskMetadata),
+    ]
 )
-def test_convert_result(para):
-    dist, preSequence, configurations, taskMetadata = para[0], para[1], para[2], para[3]
+def test_convert_result(dist, preSequence, configurations, taskMetadata):
     result = convert_result(dist, preSequence, configurations, taskMetadata)
 
     def get_meas(postSequence, num):
@@ -75,3 +76,24 @@ def test_convert_result(para):
     )
 
     assert pytest.approx(result) == pytest.approx(trueresult)
+
+@pytest.mark.parametrize(
+    "dist, preSequence, configurations, taskMetadata, expected_postSequence", [
+        ([1, 0, 0, 0], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 1, 0]),
+        ([0, 1, 0, 0], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 0, 0]),
+        ([0, 0, 1, 0], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 1, 0]),
+        ([0, 0, 0, 1], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 0, 0]),
+        
+        ([1, 0, 0, 0], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 0, 0, 0]),
+        ([0, 1, 0, 0], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 0, 0, 0]),
+        ([0, 0, 1, 0], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 0, 0, 1]),
+        ([0, 0, 0, 1], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 0, 0, 0]),
+
+        ([1, 0], [0, 0, 0, 1], ["g", "r"], mock_taskMetadata, [0, 0, 0, 1]),
+        ([0, 1], [0, 0, 0, 1], ["g", "r"], mock_taskMetadata, [0, 0, 0, 0]),
+    ]
+)
+def test_convert_result_with_empty_sites(dist, preSequence, configurations, taskMetadata, expected_postSequence):
+    result = convert_result(dist, preSequence, configurations, taskMetadata)
+    postSequence = result.measurements[0].shotResult.postSequence
+    assert result.measurements[0].shotResult.postSequence == expected_postSequence


### PR DESCRIPTION
*Issue #, if available:*

When some sites were left empty in the AHS program, the preSequence and postSequence in the results becomes inconsistent: they have different lengths, and postSequence only contains the results from non-empty sites.

This is due to a bug in `convert_result`.

*Description of changes:*

Implementation of `convert_result` is changed. Now it creates the postSequence list starting from an all-zero list of length of the preSequence, and fills in the measurement results for non-empty sites to their appropriate locations in the list.

*Testing done:*

Added test to highlight the bug to `test_convert_result.py`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
