### PR TITLE
fix: regex escape char in unit test

### DIFF
--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -1832,7 +1832,7 @@ def test_advanced_language_features(qasm, caplog):
         (
             "WARNING.*"
             "This program uses OpenQASM language features that may "
-            "not be supported on QPUs or on-demand simulators\.\n"
+            "not be supported on QPUs or on-demand simulators\\.\n"
         ),
         caplog.text,
     )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

we want "\." in the string, meaning we need to escape the backslash not the period "\\."

this change fixes a warning about invalid escape sequence "\."

*Testing done:*
unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
