### PR TITLE
Relax pydantic version constraint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,10 @@ include_trailing_comma = true
 
 [flake8]
 ignore =
-    E203,  # not pep8, black adds whitespace before ':'
-    W503,  # not pep8, black adds line break before binary operator
+    # not pep8, black adds whitespace before ':'
+    E203,
+    # not pep8, black adds line break before binary operator
+    W503,
 max_line_length = 100
 max-complexity = 10
 exclude =

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[
         "numpy",
         "opt_einsum",
-        "pydantic==1.9.0",
+        "pydantic>=1.9,<2.0",
         "scipy",
         # pinned for compatibility with strawberry fields
         "antlr4-python3-runtime==4.9.2",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, the project unnecessarily pins `pydantic`'s version to 1.9.0. This strict constraint can be problematic itself when using it as a dependency in other projects. In addition, since this project is a dependency for the `amazon-braket-sdk`, this constraint will also apply to any package that wants to integrate with Amazon Braket through the SDK. Relaxing the version constraint to any version compatible with 1.9 can guarantee that there won't be a breaking change while offering the necessary flexibility.

In addition, I fixed flake8's configuration to fit the new version 6.0.0; otherwise, it will fail.

*Testing done:*
All tests pass with `pydantic`'s latest version 1.10.2.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
