### PR TITLE
fix: remove warning for binary expressions

### DIFF
--- a/src/braket/default_simulator/openqasm/interpreter.py
+++ b/src/braket/default_simulator/openqasm/interpreter.py
@@ -190,8 +190,6 @@ class Interpreter:
 
     @visit.register
     def _(self, node: BinaryExpression) -> Union[BinaryExpression, LiteralType]:
-        if self.context.in_global_scope:
-            self._uses_advanced_language_features = True
         lhs = self.visit(node.lhs)
         rhs = self.visit(node.rhs)
         if is_literal(lhs) and is_literal(rhs):

--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -1814,7 +1814,6 @@ def test_noise():
     "qasm",
     (
         "const int x = 4;",
-        "int x = 1 + 1;",
         "qubit[2] q; h q[0:1];",
         "gate my_x q { x q; }",
         "qubit[2] q; ctrl @ x q[0], q[1];",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Now that the service supports binary expressions, this should no longer throw the "advanced language features" warning

*Testing done:*

Unit test and manual notebook example test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
