### PR TITLE
fix: remove oq3 named sims

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,16 +45,6 @@ setup(
             "braket_sv = braket.default_simulator.state_vector_simulator:StateVectorSimulator",
             "braket_dm = braket.default_simulator.density_matrix_simulator:DensityMatrixSimulator",
             (
-                "braket_oq3_sv = "
-                "braket.default_simulator.openqasm_state_vector_simulator:"
-                "OpenQASMStateVectorSimulator"
-            ),
-            (
-                "braket_oq3_dm = "
-                "braket.default_simulator.openqasm_density_matrix_simulator:"
-                "OpenQASMDensityMatrixSimulator"
-            ),
-            (
                 "braket_ahs = "
                 "braket.analog_hamiltonian_simulator.rydberg.rydberg_simulator:"
                 "RydbergAtomSimulator",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Remove sim endpoints for BraketOpenQASM simulators (point to non-existent classes)

*Testing done:*

unit tests and manually confirmed these names don't work today

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
