### PR TITLE
fix: Revert threshold to switch AHS solvers

### DIFF
--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator.py
@@ -123,7 +123,7 @@ class RydbergAtomSimulator(BaseLocalSimulator):
 
         # Run the solver
         # We shall adaptively change between numpy solver (RK6 method) and scipy solver
-        if len(self.configurations) <= 32:
+        if len(self.configurations) <= 1000:
             states = rk_run(
                 program,
                 self.configurations,


### PR DESCRIPTION
*Issue #, if available:*

[One of the recent change](https://github.com/aws/amazon-braket-default-simulator-python/blob/c71f04f792a5e0f25ef8126eae4b08f3eaa2444a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator.py#L126) causes a notebook to take long to complete. After a more careful benchmark, we decide to roll back this change.

*Description of changes:*

Change the boundary from 32 back to 1000

*Testing done:*
Yes

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
