### PR TITLE
New configurations type

### DIFF
--- a/src/braket/analog_hamiltonian_simulator/rydberg/numpy_solver.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/numpy_solver.py
@@ -28,7 +28,7 @@ _INV_EIGVECS_A = np.linalg.inv(_EIGVECS_A)
 
 def rk_run(
     program: Program,
-    configurations: List[str],
+    configurations: Dict[str, int],
     simulation_times: List[float],
     rydberg_interaction_coef: float,
     progress_bar: bool = False,
@@ -38,7 +38,7 @@ def rk_run(
 
     Args:
         program (Program): An analog simulation program for a Rydberg system
-        configurations (List[str]): The list of configurations that comply with the
+        configurations (Dict[str, int]): The list of configurations that comply with the
             blockade approximation.
         simulation_times (List[float]): The list of time points
         rydberg_interaction_coef (float): The interaction coefficient

--- a/src/braket/analog_hamiltonian_simulator/rydberg/numpy_solver.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/numpy_solver.py
@@ -1,5 +1,5 @@
 import time
-from typing import List
+from typing import List, Dict
 
 import numpy as np
 from braket.ir.ahs.program_v1 import Program

--- a/src/braket/analog_hamiltonian_simulator/rydberg/numpy_solver.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/numpy_solver.py
@@ -1,5 +1,5 @@
 import time
-from typing import List, Dict
+from typing import Dict, List
 
 import numpy as np
 from braket.ir.ahs.program_v1 import Program

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -84,7 +84,7 @@ def _get_interaction_dict(
     Args:
         program (Program): An analog simulation program for Rydberg system with the interaction term
         rydberg_interaction_coef (float): The interaction coefficient
-        configurations (List[str]): The list of configurations that comply with the blockade
+        configurations (Dict[str, int]): The list of configurations that comply with the blockade
             approximation.
 
     Returns:
@@ -213,7 +213,7 @@ def _get_sparse_ops(
 
     Args:
         program (Program): An analog simulation program for Rydberg system
-        configurations (List[str]): The list of configurations that comply with the blockade
+        configurations (Dict[str, int]): The list of configurations that comply with the blockade
             approximation.
         rydberg_interaction_coef (float): The interaction coefficient
 
@@ -373,7 +373,7 @@ def _get_ops_coefs(
 
     Args:
         program (Program): An analog simulation program for Rydberg system
-        configurations (List[str]): The list of configurations that comply to the
+        configurations (Dict[str, int]): The list of configurations that comply to the
             blockade approximation.
         rydberg_interaction_coef (float): The interaction coefficient
         simulation_times (List[float]): The list of time points

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -55,7 +55,7 @@ def get_blockade_configurations(lattice: AtomArrangement, blockade_radius: float
 
     # The coordinates for atoms in the filled sites
     atoms_coordinates = np.array(lattice.sites)[np.where(lattice.filling)]
-    min_separation = float("inf")  # The minimum separation between atoms, or filled sitesa
+    min_separation = float("inf")  # The minimum separation between atoms, or filled sites
     for i, atom_coord in enumerate(atoms_coordinates[:-1]):
         dists = np.linalg.norm(atom_coord - atoms_coordinates[i + 1 :], axis=1)
         min_separation = min(min_separation, min(dists))
@@ -148,7 +148,7 @@ def _get_detuning_dict(
 def _get_rabi_dict(
     targets: Tuple[int], configurations: Dict[str, int]
 ) -> Dict[Tuple[int, int], float]:
-    """Return the dict for the Rabi operators for a set of target atoms.
+    """Return the dict for the Rabi operator for a set of target atoms.
 
     Args:
         targets (Tuple[int]): The target atoms of the detuning operator
@@ -167,13 +167,18 @@ def _get_rabi_dict(
 
     for config_1, ind_1 in configurations.items():
         for target in targets:
+            # Only keep the lower triangular part of the Rabi operator
+            # which convert a single atom from "g" to "r".
             if config_1[target] != "g":
                 continue
 
+            # Construct the state after applying the Rabi operator
             bit_list = list(config_1)
             bit_list[target] = "r"
             config_2 = "".join(bit_list)
 
+            # If the constructed state is in the Hilbert space,
+            # add the corresponding matrix element to the Rabi operator.
             if config_2 in configurations:
                 rabi[(configurations[config_2], ind_1)] = 1
 

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_result_converter.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_result_converter.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Dict
 
 import numpy as np
 from braket.task_result.analog_hamiltonian_simulation_task_result_v1 import (
@@ -13,7 +13,7 @@ from braket.task_result.task_metadata_v1 import TaskMetadata
 def convert_result(
     dist: np.ndarray,
     pre_sequence: List[int],
-    configurations: List[str],
+    configurations: Dict[str, int],
     task_Metadata: TaskMetadata,
 ) -> AnalogHamiltonianSimulationTaskResult:
     """Convert a given sampled distribution to the analog simulation result schema
@@ -21,7 +21,7 @@ def convert_result(
     Args:
         dist (ndarray): The sample results to convert
         pre_sequence (List[int]): the same pre-sequence measurement results used for all shots
-        configurations (List[str]): The list of configurations that comply with the blockade
+        configurations (Dict[str, int]): The list of configurations that comply with the blockade
             approximation.
         task_Metadata (TaskMetadata): The metadata for the task
 

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_result_converter.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_result_converter.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import Dict, List
 
 import numpy as np
 from braket.task_result.analog_hamiltonian_simulation_task_result_v1 import (

--- a/src/braket/analog_hamiltonian_simulator/rydberg/scipy_solver.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/scipy_solver.py
@@ -1,5 +1,5 @@
 import time
-from typing import List
+from typing import List, Dict
 
 import numpy as np
 import scipy.integrate
@@ -15,7 +15,7 @@ from braket.analog_hamiltonian_simulator.rydberg.rydberg_simulator_helpers impor
 
 def scipy_integrate_ode_run(
     program: Program,
-    configurations: List[str],
+    configurations: Dict[str, int],
     simulation_times: List[float],
     rydberg_interaction_coef: float,
     progress_bar: bool = False,
@@ -33,7 +33,7 @@ def scipy_integrate_ode_run(
 
     Args:
         program (Program): An analog simulation Hamiltonian for the Rydberg system simulated
-        configurations (List[str]): The list of configurations that comply with the
+        configurations (Dict[str, int]): The list of configurations that comply with the
             blockade approximation.
         simulation_times (List[float]): The list of time points
         rydberg_interaction_coef (float): The interaction coefficient

--- a/src/braket/analog_hamiltonian_simulator/rydberg/scipy_solver.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/scipy_solver.py
@@ -1,5 +1,5 @@
 import time
-from typing import List, Dict
+from typing import Dict, List
 
 import numpy as np
 import scipy.integrate

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_convert_result.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_convert_result.py
@@ -13,7 +13,7 @@ from braket.analog_hamiltonian_simulator.rydberg.rydberg_simulator_result_conver
     convert_result,
 )
 
-configurations_1 = ["gg", "gr", "rg", "rr"]
+configurations_1 = {"gg": 0, "gr": 1, "rg": 2, "rr": 3}
 
 shots = 10000000
 
@@ -82,16 +82,64 @@ def test_convert_result(dist, preSequence, configurations, taskMetadata):
 @pytest.mark.parametrize(
     "dist, preSequence, configurations, taskMetadata, expected_postSequence",
     [
-        ([1, 0, 0, 0], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 1, 0]),
-        ([0, 1, 0, 0], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 0, 0]),
-        ([0, 0, 1, 0], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 1, 0]),
-        ([0, 0, 0, 1], [1, 1, 0], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 0, 0]),
-        ([1, 0, 0, 0], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 0, 0, 1]),
-        ([0, 1, 0, 0], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [1, 0, 0, 0]),
-        ([0, 0, 1, 0], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 0, 0, 1]),
-        ([0, 0, 0, 1], [1, 0, 0, 1], ["gg", "gr", "rg", "rr"], mock_taskMetadata, [0, 0, 0, 0]),
-        ([1, 0], [0, 0, 0, 1], ["g", "r"], mock_taskMetadata, [0, 0, 0, 1]),
-        ([0, 1], [0, 0, 0, 1], ["g", "r"], mock_taskMetadata, [0, 0, 0, 0]),
+        (
+            [1, 0, 0, 0],
+            [1, 1, 0],
+            {"gg": 0, "gr": 1, "rg": 2, "rr": 3},
+            mock_taskMetadata,
+            [1, 1, 0],
+        ),
+        (
+            [0, 1, 0, 0],
+            [1, 1, 0],
+            {"gg": 0, "gr": 1, "rg": 2, "rr": 3},
+            mock_taskMetadata,
+            [1, 0, 0],
+        ),
+        (
+            [0, 0, 1, 0],
+            [1, 1, 0],
+            {"gg": 0, "gr": 1, "rg": 2, "rr": 3},
+            mock_taskMetadata,
+            [0, 1, 0],
+        ),
+        (
+            [0, 0, 0, 1],
+            [1, 1, 0],
+            {"gg": 0, "gr": 1, "rg": 2, "rr": 3},
+            mock_taskMetadata,
+            [0, 0, 0],
+        ),
+        (
+            [1, 0, 0, 0],
+            [1, 0, 0, 1],
+            {"gg": 0, "gr": 1, "rg": 2, "rr": 3},
+            mock_taskMetadata,
+            [1, 0, 0, 1],
+        ),
+        (
+            [0, 1, 0, 0],
+            [1, 0, 0, 1],
+            {"gg": 0, "gr": 1, "rg": 2, "rr": 3},
+            mock_taskMetadata,
+            [1, 0, 0, 0],
+        ),
+        (
+            [0, 0, 1, 0],
+            [1, 0, 0, 1],
+            {"gg": 0, "gr": 1, "rg": 2, "rr": 3},
+            mock_taskMetadata,
+            [0, 0, 0, 1],
+        ),
+        (
+            [0, 0, 0, 1],
+            [1, 0, 0, 1],
+            {"gg": 0, "gr": 1, "rg": 2, "rr": 3},
+            mock_taskMetadata,
+            [0, 0, 0, 0],
+        ),
+        ([1, 0], [0, 0, 0, 1], {"g": 0, "r": 1}, mock_taskMetadata, [0, 0, 0, 1]),
+        ([0, 1], [0, 0, 0, 1], {"g": 0, "r": 1}, mock_taskMetadata, [0, 0, 0, 0]),
     ],
 )
 def test_convert_result_with_empty_sites(

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_blockade_configurations.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_blockade_configurations.py
@@ -60,14 +60,23 @@ def test_validate_config_1_fail(para):
 def test_get_blockade_configurations_setup_1_blockade(para):
     lattice, blockade_radius = para[0], para[1]
     configurations = get_blockade_configurations(lattice, blockade_radius)
-    assert configurations == ["ggg", "ggr", "grg", "rgg", "rgr"]
+    assert configurations == {"ggg": 0, "ggr": 1, "grg": 2, "rgg": 3, "rgr": 4}
 
 
 @pytest.mark.parametrize("para", [[setup_1, 0]])
 def test_get_blockade_configurations_setup_1_no_blockade(para):
     lattice, blockade_radius = para[0], para[1]
     configurations = get_blockade_configurations(lattice, blockade_radius)
-    assert configurations == ["ggg", "ggr", "grg", "grr", "rgg", "rgr", "rrg", "rrr"]
+    assert configurations == {
+        "ggg": 0,
+        "ggr": 1,
+        "grg": 2,
+        "grr": 3,
+        "rgg": 4,
+        "rgr": 5,
+        "rrg": 6,
+        "rrr": 7,
+    }
 
 
 ###
@@ -111,21 +120,21 @@ def test_validate_config_2_fail(para):
 def test_get_blockade_configurations_setup_2_blockade_1(para):
     lattice, blockade_radius = para[0], para[1]
     configurations = get_blockade_configurations(lattice, blockade_radius)
-    assert configurations == ["gg", "gr", "rg", "rr"]
+    assert configurations == {"gg": 0, "gr": 1, "rg": 2, "rr": 3}
 
 
 @pytest.mark.parametrize("para", [[setup_2, 6e-6]])
 def test_get_blockade_configurations_setup_2_blockade_2(para):
     lattice, blockade_radius = para[0], para[1]
     configurations = get_blockade_configurations(lattice, blockade_radius)
-    assert configurations == ["gg", "gr", "rg"]
+    assert configurations == {"gg": 0, "gr": 1, "rg": 2}
 
 
 @pytest.mark.parametrize("para", [[setup_2, 0]])
 def test_get_blockade_configurations_setup_2_no_blockade(para):
     lattice, blockade_radius = para[0], para[1]
     configurations = get_blockade_configurations(lattice, blockade_radius)
-    assert configurations == ["gg", "gr", "rg", "rr"]
+    assert configurations == {"gg": 0, "gr": 1, "rg": 2, "rr": 3}
 
 
 ###
@@ -170,11 +179,11 @@ def test_validate_config_3_fail(para):
 def test_get_blockade_configurations_setup_3_blockade(para):
     lattice, blockade_radius = para[0], para[1]
     configurations = get_blockade_configurations(lattice, blockade_radius)
-    assert configurations == ["gg", "gr", "rg"]
+    assert configurations == {"gg": 0, "gr": 1, "rg": 2}
 
 
 @pytest.mark.parametrize("para", [[setup_2, 0]])
 def test_get_blockade_configurations_setup_3_no_blockade(para):
     lattice, blockade_radius = para[0], para[1]
     configurations = get_blockade_configurations(lattice, blockade_radius)
-    assert configurations == ["gg", "gr", "rg", "rr"]
+    assert configurations == {"gg": 0, "gr": 1, "rg": 2, "rr": 3}

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_coefs.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_coefs.py
@@ -46,7 +46,7 @@ program_1 = convert_unit(
     )
 )
 
-configurations1 = ["gg", "gr", "rg", "rr"]
+configurations1 = {"gg": 0, "gr": 1, "rg": 2, "rr": 3}
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_dicts_ops.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_dicts_ops.py
@@ -45,7 +45,7 @@ program_1 = convert_unit(
     )
 )
 
-configurations_1 = ["gg", "gr", "rg", "rr"]
+configurations_1 = {"gg": 0, "gr": 1, "rg": 2, "rr": 3}
 
 
 @pytest.mark.parametrize("para", [[program_1, rydberg_interaction_coef, configurations_1]])
@@ -94,7 +94,7 @@ program_2 = convert_unit(
     )
 )
 
-configurations_2 = ["gg", "gr", "rg", "rr"]
+configurations_2 = {"gg": 0, "gr": 1, "rg": 2, "rr": 3}
 
 
 @pytest.mark.parametrize("para", [[program_2, rydberg_interaction_coef, configurations_2]])
@@ -117,7 +117,7 @@ program_3 = convert_unit(
     )
 )
 
-configurations_3 = ["ggg", "ggr", "grg", "grr", "rgg", "rgr", "rrg", "rrr"]
+configurations_3 = {"ggg": 0, "ggr": 1, "grg": 2, "grr": 3, "rgg": 4, "rgr": 5, "rrg": 6, "rrr": 7}
 
 
 @pytest.mark.parametrize("para", [[program_3, rydberg_interaction_coef, configurations_3]])

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_dicts_ops.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_dicts_ops.py
@@ -206,3 +206,37 @@ def test_get_detuning_dict_configurations_3_6():
     assert _get_detuning_dict((0, 1, 2), configurations_3) == dict(
         {(1, 1): 1, (2, 2): 1, (3, 3): 2, (6, 6): 2, (7, 7): 3, (4, 4): 1, (5, 5): 2}
     )
+
+configurations_4 = {"gg": 0, "gr": 1, "rg": 2}
+
+
+@pytest.mark.parametrize("para", [[program_1, rydberg_interaction_coef, configurations_4]])
+def test_get_interaction_dict_setup_4(para):
+    program, rydberg_interaction_coef, configurations = para[0], para[1], para[2]
+    interaction = _get_interaction_dict(program, rydberg_interaction_coef, configurations)
+
+    assert interaction == dict()
+
+
+def test_get_detuning_dict_configurations_4_1():
+    assert _get_detuning_dict((0,), configurations_4) == dict({(2, 2): 1})
+
+
+def test_get_detuning_dict_configurations_4_2():
+    assert _get_detuning_dict((1,), configurations_4) == dict({(1, 1): 1})
+
+
+def test_get_detuning_dict_configurations_4_3():
+    assert _get_detuning_dict((0, 1), configurations_4) == dict({(1, 1): 1, (2, 2): 1})
+
+
+def test_get_rabi_dict_configurations_4_1():
+    assert _get_rabi_dict((0,), configurations_4) == dict({(2, 0): 1})
+
+
+def test_get_rabi_dict_configurations_4_2():
+    assert _get_rabi_dict((1,), configurations_4) == dict({(1, 0): 1})
+
+
+def test_get_rabi_dict_configurations_4_3():
+    assert _get_rabi_dict((0, 1), configurations_4) == dict({(1, 0): 1, (2, 0): 1})

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_dicts_ops.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_dicts_ops.py
@@ -207,6 +207,7 @@ def test_get_detuning_dict_configurations_3_6():
         {(1, 1): 1, (2, 2): 1, (3, 3): 2, (6, 6): 2, (7, 7): 3, (4, 4): 1, (5, 5): 2}
     )
 
+
 configurations_4 = {"gg": 0, "gr": 1, "rg": 2}
 
 

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_ops_coefs.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_ops_coefs.py
@@ -44,7 +44,7 @@ program_1 = convert_unit(
     )
 )
 
-configurations_1 = ["gg", "gr", "rg", "rr"]
+configurations_1 = {"gg": 0, "gr": 1, "rg": 2, "rr": 3}
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_sparse_ops.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_sparse_ops.py
@@ -43,7 +43,7 @@ program1 = convert_unit(
     )
 )
 
-configurations_1 = ["gg", "gr", "rg", "rr"]
+configurations_1 = {"gg": 0, "gr": 1, "rg": 2, "rr": 3}
 
 
 def test_get_sparse_from_dict_1():

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_solvers.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_solvers.py
@@ -53,7 +53,7 @@ program = convert_unit(
     )
 )
 
-configurations = ["gg", "gr", "rg", "rr"]
+configurations = {"gg": 0, "gr": 1, "rg": 2, "rr": 3}
 steps = 400
 simulation_times = np.linspace(0, tmax * 1e6, steps)
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Construction of the Rabi-term is currently not optimal. The optimal implementation scales as the size of the configurations. To achieve this performance in the current implementation, I have made the following changes:

1. Use a dictionary for `configurations` to map the Rydberg bit-string to the Hilbert space index.
2. In the function `_get_rabi_dict`, I removed the inner loop over the configurations. This loop is replaced with a loop over the targets, combining with the dictionary for `configurations`. The scaling of the function now goes as `O(len(configuration)*len(targets))`.

*Testing done:*

unit tests: passing
performence test: again shows regression 

```
Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
--------------------------------------------------------------------------------------------------------------------------------------------------------
Performance has regressed:
        test_grcs_simulation (0001_da005c9) - Field 'min' has failed PercentageRegressionCheck: 39.463113812 > 5.000000000
        test_layered_continuous_gates_circuit[14-12] (0001_da005c9) - Field 'min' has failed PercentageRegressionCheck: 42.145271715 > 5.000000000
        test_layered_continuous_gates_circuit[18-4] (0001_da005c9) - Field 'min' has failed PercentageRegressionCheck: 19.681088429 > 5.000000000
        test_layered_continuous_gates_circuit[18-20] (0001_da005c9) - Field 'min' has failed PercentageRegressionCheck: 10.391900947 > 5.000000000
--------------------------------------------------------------------------------------------------------------------------------------------------------
```

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
