### PR TITLE
feat: optimize performance for simulating control modifiers

### DIFF
--- a/src/braket/default_simulator/linalg_utils.py
+++ b/src/braket/default_simulator/linalg_utils.py
@@ -44,12 +44,8 @@ def apply_operation(
     control_state = control_state or (1,) * len(controls)
     num_qubits = len(state.shape)
     slices = (slice(None, 1), slice(1, None), slice(None, None))
-    control_slices = {
-        i: slices[state] for i, state in zip(controls, control_state)
-    }
-    ctrl_index = tuple(
-        control_slices[i] if i in controls else slices[2] for i in range(num_qubits)
-    )
+    control_slices = {i: slices[state] for i, state in zip(controls, control_state)}
+    ctrl_index = tuple(control_slices[i] if i in controls else slices[2] for i in range(num_qubits))
     state[ctrl_index] = multiply_matrix(state[ctrl_index], matrix, targets)
     return state
 

--- a/src/braket/default_simulator/linalg_utils.py
+++ b/src/braket/default_simulator/linalg_utils.py
@@ -17,7 +17,48 @@ from typing import List, Optional, Sequence, Tuple
 import numpy as np
 
 
-def multiply_matrix(state: np.ndarray, matrix: np.ndarray, targets: Tuple[int, ...]) -> np.ndarray:
+def apply_operation(
+    state: np.ndarray,
+    matrix: np.ndarray,
+    targets: Tuple[int, ...],
+    controls: Optional[Tuple[int]] = (),
+    control_state: Optional[Tuple[int]] = (),
+) -> np.ndarray:
+    """Applies the given matrix to the given state, controlling the operation as specified.
+
+    Args:
+        state (np.ndarray): The state to multiply the matrix by.
+        matrix (np.ndarray): The matrix to apply to the state.
+        targets (Tuple[int]): The qubits to apply the state on.
+        controls (Optional[Tuple[int]]): The qubits to control the operation on. Default ().
+        control_state (Optional[Tuple[int]]): A tuple of same length as `controls` with either
+            a 0 or 1 in each index, corresponding to whether to control on the |0⟩ or |1⟩ state.
+            Default (1,) * len(controls).
+
+    Returns:
+        np.ndarray: The state after the matrix has been applied.
+    """
+    if not controls:
+        return multiply_matrix(state, matrix, targets)
+
+    control_state = control_state or (1,) * len(controls)
+    num_qubits = len(state.shape)
+    control_slices = {
+        i: (slice(None, 1), slice(1, None))[state]
+        for i, state in zip(controls, control_state)
+    }
+    ctrl_index = tuple(
+        control_slices[i] if i in controls else slice(None, None) for i in range(num_qubits)
+    )
+    state[ctrl_index] = multiply_matrix(state[ctrl_index], matrix, targets)
+    return state
+
+
+def multiply_matrix(
+    state: np.ndarray,
+    matrix: np.ndarray,
+    targets: Tuple[int, ...],
+) -> np.ndarray:
     """Multiplies the given matrix by the given state, applying the matrix on the target qubits.
 
     Args:
@@ -118,27 +159,4 @@ def _get_target_permutation(targets: Sequence[int]) -> Sequence[int]:
     basis_states = np.array(list(itertools.product([0, 1], repeat=len(targets))))
     return np.ravel_multi_index(
         basis_states[:, np.argsort(np.argsort(targets))].T, [2] * len(targets)
-    )
-
-
-def controlled_unitary(unitary: np.ndarray, negctrl: bool = False) -> np.ndarray:
-    """
-    Transform unitary matrix into a controlled unitary matrix.
-
-    Args:
-        unitary (np.ndarray): Unitary matrix operation.
-        negctrl (bool): Whether to control the operation on the |0⟩ state,
-            instead of the |1⟩ state. Default: False.
-
-    Returns:
-        np.ndarray: A controlled version of the provided unitary matrix.
-    """
-    upper_left, bottom_right = np.eye(unitary.shape[0]), unitary
-    if negctrl:
-        upper_left, bottom_right = bottom_right, upper_left
-    return np.block(
-        [
-            [upper_left, np.zeros_like(unitary)],
-            [np.zeros_like(unitary), bottom_right],
-        ]
     )

--- a/src/braket/default_simulator/linalg_utils.py
+++ b/src/braket/default_simulator/linalg_utils.py
@@ -44,8 +44,7 @@ def apply_operation(
     control_state = control_state or (1,) * len(controls)
     num_qubits = len(state.shape)
     control_slices = {
-        i: (slice(None, 1), slice(1, None))[state]
-        for i, state in zip(controls, control_state)
+        i: (slice(None, 1), slice(1, None))[state] for i, state in zip(controls, control_state)
     }
     ctrl_index = tuple(
         control_slices[i] if i in controls else slice(None, None) for i in range(num_qubits)

--- a/src/braket/default_simulator/linalg_utils.py
+++ b/src/braket/default_simulator/linalg_utils.py
@@ -46,7 +46,7 @@ def multiply_matrix(
         np.ndarray: The state after the matrix has been applied.
     """
     if not controls:
-        return multiply_matrix(state, matrix, targets)
+        return _multiply_matrix(state, matrix, targets)
 
     control_state = control_state or (1,) * len(controls)
     num_qubits = len(state.shape)

--- a/src/braket/default_simulator/linalg_utils.py
+++ b/src/braket/default_simulator/linalg_utils.py
@@ -16,15 +16,22 @@ from typing import List, Optional, Sequence, Tuple
 
 import numpy as np
 
+_SLICES = (
+    _CONTROL_SLICE := slice(1, None),
+    _NEG_CONTROL_SLICE := slice(None, 1),
+    _NO_CONTROL_SLICE := slice(None, None),
+)
 
-def apply_operation(
+
+def multiply_matrix(
     state: np.ndarray,
     matrix: np.ndarray,
     targets: Tuple[int, ...],
     controls: Optional[Tuple[int]] = (),
     control_state: Optional[Tuple[int]] = (),
 ) -> np.ndarray:
-    """Applies the given matrix to the given state, controlling the operation as specified.
+    """Multiplies the given matrix by the given state, applying the matrix on the target qubits,
+    controlling the operation as specified.
 
     Args:
         state (np.ndarray): The state to multiply the matrix by.
@@ -43,14 +50,15 @@ def apply_operation(
 
     control_state = control_state or (1,) * len(controls)
     num_qubits = len(state.shape)
-    slices = (slice(None, 1), slice(1, None), slice(None, None))
-    control_slices = {i: slices[state] for i, state in zip(controls, control_state)}
-    ctrl_index = tuple(control_slices[i] if i in controls else slices[2] for i in range(num_qubits))
+    control_slices = {i: _SLICES[state] for i, state in zip(controls, control_state)}
+    ctrl_index = tuple(
+        control_slices[i] if i in controls else _NO_CONTROL_SLICE for i in range(num_qubits)
+    )
     state[ctrl_index] = multiply_matrix(state[ctrl_index], matrix, targets)
     return state
 
 
-def multiply_matrix(
+def _multiply_matrix(
     state: np.ndarray,
     matrix: np.ndarray,
     targets: Tuple[int, ...],

--- a/src/braket/default_simulator/linalg_utils.py
+++ b/src/braket/default_simulator/linalg_utils.py
@@ -43,11 +43,12 @@ def apply_operation(
 
     control_state = control_state or (1,) * len(controls)
     num_qubits = len(state.shape)
+    slices = (slice(None, 1), slice(1, None), slice(None, None))
     control_slices = {
-        i: (slice(None, 1), slice(1, None))[state] for i, state in zip(controls, control_state)
+        i: slices[state] for i, state in zip(controls, control_state)
     }
     ctrl_index = tuple(
-        control_slices[i] if i in controls else slice(None, None) for i in range(num_qubits)
+        control_slices[i] if i in controls else slices[2] for i in range(num_qubits)
     )
     state[ctrl_index] = multiply_matrix(state[ctrl_index], matrix, targets)
     return state

--- a/src/braket/default_simulator/linalg_utils.py
+++ b/src/braket/default_simulator/linalg_utils.py
@@ -17,8 +17,8 @@ from typing import List, Optional, Sequence, Tuple
 import numpy as np
 
 _SLICES = (
-    _CONTROL_SLICE := slice(1, None),
     _NEG_CONTROL_SLICE := slice(None, 1),
+    _CONTROL_SLICE := slice(1, None),
     _NO_CONTROL_SLICE := slice(None, None),
 )
 

--- a/src/braket/default_simulator/linalg_utils.py
+++ b/src/braket/default_simulator/linalg_utils.py
@@ -54,7 +54,7 @@ def multiply_matrix(
     ctrl_index = tuple(
         control_slices[i] if i in controls else _NO_CONTROL_SLICE for i in range(num_qubits)
     )
-    state[ctrl_index] = multiply_matrix(state[ctrl_index], matrix, targets)
+    state[ctrl_index] = _multiply_matrix(state[ctrl_index], matrix, targets)
     return state
 
 

--- a/src/braket/default_simulator/operation.py
+++ b/src/braket/default_simulator/operation.py
@@ -19,8 +19,6 @@ from typing import List, Optional, Tuple
 import numpy as np
 from scipy.linalg import fractional_matrix_power
 
-from braket.default_simulator.linalg_utils import controlled_unitary
-
 
 class Operation(ABC):
     """

--- a/src/braket/default_simulator/operation.py
+++ b/src/braket/default_simulator/operation.py
@@ -50,6 +50,7 @@ class GateOperation(Operation, ABC):
         self._ctrl_modifiers = ctrl_modifiers
         self._power = power
 
+    @property
     @abstractmethod
     def _base_matrix(self) -> np.ndarray:
         """np.ndarray: The matrix representation of the operation."""
@@ -61,9 +62,6 @@ class GateOperation(Operation, ABC):
             unitary = np.linalg.matrix_power(unitary, int(self._power))
         else:
             unitary = fractional_matrix_power(unitary, self._power)
-
-        for mod in self._ctrl_modifiers:
-            unitary = controlled_unitary(unitary, negctrl=mod)
         return unitary
 
     def __eq__(self, other):

--- a/src/braket/default_simulator/simulation_strategies/single_operation_strategy.py
+++ b/src/braket/default_simulator/simulation_strategies/single_operation_strategy.py
@@ -41,5 +41,5 @@ def apply_operations(
         control_state = tuple(np.logical_not(operation._ctrl_modifiers).astype(int))
         controls = all_targets[:num_ctrl]
         targets = all_targets[num_ctrl:]
-        state = apply_operation(state, matrix, targets, controls, control_state)
+        state = multiply_matrix(state, matrix, targets, controls, control_state)
     return state

--- a/src/braket/default_simulator/simulation_strategies/single_operation_strategy.py
+++ b/src/braket/default_simulator/simulation_strategies/single_operation_strategy.py
@@ -15,7 +15,7 @@ from typing import List
 
 import numpy as np
 
-from braket.default_simulator.linalg_utils import apply_operation
+from braket.default_simulator.linalg_utils import multiply_matrix
 from braket.default_simulator.operation import GateOperation
 
 

--- a/src/braket/default_simulator/simulation_strategies/single_operation_strategy.py
+++ b/src/braket/default_simulator/simulation_strategies/single_operation_strategy.py
@@ -15,7 +15,7 @@ from typing import List
 
 import numpy as np
 
-from braket.default_simulator.linalg_utils import multiply_matrix
+from braket.default_simulator.linalg_utils import apply_operation
 from braket.default_simulator.operation import GateOperation
 
 
@@ -36,6 +36,10 @@ def apply_operations(
     """
     for operation in operations:
         matrix = operation.matrix
-        targets = operation.targets
-        state = multiply_matrix(state, matrix, targets)
+        all_targets = operation.targets
+        num_ctrl = len(operation._ctrl_modifiers)
+        control_state = tuple(np.logical_not(operation._ctrl_modifiers).astype(int))
+        controls = all_targets[:num_ctrl]
+        targets = all_targets[num_ctrl:]
+        state = apply_operation(state, matrix, targets, controls, control_state)
     return state

--- a/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
+++ b/test/unit_tests/braket/default_simulator/openqasm/test_interpreter.py
@@ -1028,7 +1028,6 @@ def test_gphase():
     circuit = Interpreter().build_circuit(qasm)
     simulation = StateVectorSimulation(2, 1, 1)
     simulation.evolve(circuit.instructions)
-    print(simulation.state_vector)
     assert np.allclose(simulation.state_vector, [-1 / np.sqrt(2), 0, 0, 1 / np.sqrt(2)])
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Instead of building a controlled unitary, which grows exponentially wrt to the number of control qubits, mask the state to only update the halves that fall under the control condition.

Nits:
- removed "public" method `controlled_unitary` from linalg_utils, since it's no longer used; can keep this around if this would be considered breaking
- Currently the interpreter tracks the ctrl/negctrl enum as 0/1 respectively, which is flipped from the control state. Have kept this field as private to not highlight this, can shift this approach around as preferred.

*Testing done:*

Existing unit testing

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
