### PR TITLE
New implementation for helper `_get_rabi_dict` in rydberg AHS. 

### DIFF
--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -161,9 +161,7 @@ def _get_rabi_dict(targets: Tuple[int], configurations: List[str]) -> Dict[Tuple
     rabi = {}  # The Rabi term in the basis of configurations, as a dictionary
 
     # use dictionary to store index of configurations
-    configuration_index = {
-        config: ind for ind, config in enumerate(configurations)
-    }
+    configuration_index = {config: ind for ind, config in enumerate(configurations)}
 
     for ind_1, config_1 in enumerate(configurations):
         for target in targets:
@@ -181,7 +179,7 @@ def _get_rabi_dict(targets: Tuple[int], configurations: List[str]) -> Dict[Tuple
             # add the corresponding matrix element to the Rabi operator.
             if config_2 in configuration_index:
                 rabi[(configuration_index[config_2], ind_1)] = 1
-                
+
     return rabi
 
 

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -160,30 +160,28 @@ def _get_rabi_dict(targets: Tuple[int], configurations: List[str]) -> Dict[Tuple
 
     rabi = {}  # The Rabi term in the basis of configurations, as a dictionary
 
+    # use dictionary to store index of configurations
+    configuration_index = {
+        config: ind for ind, config in enumerate(configurations)
+    }
+
     for ind_1, config_1 in enumerate(configurations):
-        for ind_2, config_2 in enumerate(configurations):
-            if ind_2 > ind_1:
-                # Obtain the indices of the bits where config_1 differ from config_2
-                ind_diffs = [
-                    ind for ind, (bit1, bit2) in enumerate(zip(config_1, config_2)) if bit1 != bit2
-                ]
+        for target in targets:
+            # Only keep the lower triangular part of the Rabi operator
+            # which convert a single atom from "g" to "r".
+            if config_1[target] != "g":
+                continue
 
-                # The Rabi term will be nonzero iff the two configurations differ
-                # by one and only one bit
-                if len(ind_diffs) > 1:
-                    continue
+            # Construct the state after applying the Rabi operator
+            bit_list = list(config_1)
+            bit_list[target] = "r"
+            config_2 = "".join(bit_list)
 
-                index_diff = ind_diffs[0]  # The index where config_1 differ from config_2
-
-                # If the index_diff is not in the target, then it won't contribute to the
-                # Rabi operator
-                if index_diff not in targets:
-                    continue
-
-                # Only keep the lower triangular part of the Rabi operator
-                # In particular, we only add the following component if and only if
-                # (config_1[index_diff], config_2[index_diff]) == ("g", "r")
-                rabi[(ind_2, ind_1)] = 1
+            # If the constructed state is in the Hilbert space,
+            # add the corresponding matrix element to the Rabi operator.
+            if config_2 in configuration_index:
+                rabi[(configuration_index[config_2], ind_1)] = 1
+                
     return rabi
 
 

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -55,7 +55,7 @@ def get_blockade_configurations(lattice: AtomArrangement, blockade_radius: float
 
     # The coordinates for atoms in the filled sites
     atoms_coordinates = np.array(lattice.sites)[np.where(lattice.filling)]
-    min_separation = 1e10  # The minimum separation between atoms, or filled sites
+    min_separation = float("inf")  # The minimum separation between atoms, or filled sites
     for i, atom_coord in enumerate(atoms_coordinates[:-1]):
         dists = np.linalg.norm(atom_coord - atoms_coordinates[i + 1 :], axis=1)
         min_separation = min(min_separation, min(dists))

--- a/test/.benchmarks/Darwin-CPython-3.9-64bit/0001_e09fe39b7d0b877e70e15e6d4aa27c25eb54654b_20230415_181107.json
+++ b/test/.benchmarks/Darwin-CPython-3.9-64bit/0001_e09fe39b7d0b877e70e15e6d4aa27c25eb54654b_20230415_181107.json
@@ -1,0 +1,1171 @@
+{
+    "machine_info": {
+        "node": "pweinbergmac.local",
+        "processor": "i386",
+        "machine": "x86_64",
+        "python_compiler": "Clang 14.0.6 ",
+        "python_implementation": "CPython",
+        "python_implementation_version": "3.9.16",
+        "python_version": "3.9.16",
+        "python_build": [
+            "main",
+            "Mar  8 2023 04:29:44"
+        ],
+        "release": "21.6.0",
+        "system": "Darwin",
+        "cpu": {
+            "python_version": "3.9.16.final.0 (64 bit)",
+            "cpuinfo_version": [
+                8,
+                0,
+                0
+            ],
+            "cpuinfo_version_string": "8.0.0",
+            "arch": "X86_64",
+            "bits": 64,
+            "count": 10,
+            "arch_string_raw": "x86_64",
+            "brand_raw": "Apple M1 Pro",
+            "hz_actual_friendly": "2.4000 GHz",
+            "hz_actual": [
+                2400000000,
+                0
+            ],
+            "family": 6,
+            "flags": [
+                "acpi",
+                "aes",
+                "apic",
+                "clflush",
+                "clfsh",
+                "cmov",
+                "cx16",
+                "cx8",
+                "de",
+                "ds",
+                "dscpl",
+                "dtes64",
+                "dtse64",
+                "est",
+                "fpu",
+                "fxsr",
+                "htt",
+                "lahf_lm",
+                "mca",
+                "mce",
+                "mmx",
+                "mon",
+                "monitor",
+                "msr",
+                "mtrr",
+                "pae",
+                "pat",
+                "pbe",
+                "pclmulqdq",
+                "pdcm",
+                "pge",
+                "pni",
+                "popcnt",
+                "pse",
+                "pse36",
+                "seglim64",
+                "sep",
+                "ss",
+                "sse",
+                "sse2",
+                "sse3",
+                "sse4.1",
+                "sse4.2",
+                "sse4_1",
+                "sse4_2",
+                "ssse3",
+                "tm",
+                "tm2",
+                "tpr",
+                "tsc",
+                "vme",
+                "vmx"
+            ],
+            "vendor_id_raw": "GenuineIntel",
+            "hz_advertised_friendly": "2.5000 GHz",
+            "hz_advertised": [
+                2500000000,
+                0
+            ],
+            "l2_cache_size": 65536,
+            "l2_cache_line_size": 8192,
+            "l2_cache_associativity": 8,
+            "model": 44
+        }
+    },
+    "commit_info": {
+        "id": "e09fe39b7d0b877e70e15e6d4aa27c25eb54654b",
+        "time": "2023-04-15T14:06:57-04:00",
+        "author_time": "2023-04-15T14:06:57-04:00",
+        "dirty": false,
+        "project": "amazon-braket-default-simulator-python",
+        "branch": "benchmarks-branch"
+    },
+    "benchmarks": [
+        {
+            "group": null,
+            "name": "test_grcs_simulation",
+            "fullname": "test/performance/test_performance.py::test_grcs_simulation",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.31433900000000037,
+                "max": 0.38647399999999976,
+                "mean": 0.3462232,
+                "stddev": 0.03339875846045736,
+                "rounds": 5,
+                "median": 0.33131799999999956,
+                "iqr": 0.060215999999998715,
+                "q1": 0.3196130000000008,
+                "q3": 0.37982899999999953,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.31433900000000037,
+                "hd15iqr": 0.38647399999999976,
+                "ops": 2.888310199894172,
+                "total": 1.731116,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_qft[4]",
+            "fullname": "test/performance/test_performance.py::test_qft[4]",
+            "params": {
+                "nqubits": 4
+            },
+            "param": "4",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.001298999999999495,
+                "max": 0.001784000000000674,
+                "mean": 0.0013156467991170297,
+                "stddev": 2.9278850375938723e-05,
+                "rounds": 453,
+                "median": 0.001312000000000424,
+                "iqr": 6.9999999983139105e-06,
+                "q1": 0.0013090000000008928,
+                "q3": 0.0013159999999992067,
+                "iqr_outliers": 19,
+                "stddev_outliers": 10,
+                "outliers": "10;19",
+                "ld15iqr": 0.001298999999999495,
+                "hd15iqr": 0.001328000000000884,
+                "ops": 760.0824177667823,
+                "total": 0.5959880000000144,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_qft[8]",
+            "fullname": "test/performance/test_performance.py::test_qft[8]",
+            "params": {
+                "nqubits": 8
+            },
+            "param": "8",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.002350999999999104,
+                "max": 0.002456000000000458,
+                "mean": 0.002366211267605592,
+                "stddev": 1.0832737518920317e-05,
+                "rounds": 426,
+                "median": 0.0023640000000000327,
+                "iqr": 9.000000000369823e-06,
+                "q1": 0.0023599999999994736,
+                "q3": 0.0023689999999998435,
+                "iqr_outliers": 19,
+                "stddev_outliers": 51,
+                "outliers": "51;19",
+                "ld15iqr": 0.002350999999999104,
+                "hd15iqr": 0.0023839999999992756,
+                "ops": 422.6165320444596,
+                "total": 1.0080059999999822,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_qft[12]",
+            "fullname": "test/performance/test_performance.py::test_qft[12]",
+            "params": {
+                "nqubits": 12
+            },
+            "param": "12",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.006380999999999304,
+                "max": 0.006776999999999589,
+                "mean": 0.006414273885350189,
+                "stddev": 5.594452511708192e-05,
+                "rounds": 157,
+                "median": 0.006401999999999575,
+                "iqr": 1.2999999999152578e-05,
+                "q1": 0.006394000000000233,
+                "q3": 0.006406999999999385,
+                "iqr_outliers": 19,
+                "stddev_outliers": 8,
+                "outliers": "8;19",
+                "ld15iqr": 0.006380999999999304,
+                "hd15iqr": 0.006426999999998628,
+                "ops": 155.90229196229663,
+                "total": 1.0070409999999796,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_qft[16]",
+            "fullname": "test/performance/test_performance.py::test_qft[16]",
+            "params": {
+                "nqubits": 16
+            },
+            "param": "16",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.5116439999999969,
+                "max": 0.6640100000000011,
+                "mean": 0.6099149999999994,
+                "stddev": 0.0622466225469318,
+                "rounds": 5,
+                "median": 0.6111329999999988,
+                "iqr": 0.08541800000000155,
+                "q1": 0.5777932499999991,
+                "q3": 0.6632112500000007,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.5116439999999969,
+                "hd15iqr": 0.6640100000000011,
+                "ops": 1.6395727273472547,
+                "total": 3.0495749999999973,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[2-4]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[2-4]",
+            "params": {
+                "nqubits": 2,
+                "nlayers": 4
+            },
+            "param": "2-4",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.0015639999999983445,
+                "max": 0.0016809999999978231,
+                "mean": 0.0015814420485176588,
+                "stddev": 1.2033456069752196e-05,
+                "rounds": 371,
+                "median": 0.001578999999999553,
+                "iqr": 8.000000001118224e-06,
+                "q1": 0.0015760000000000218,
+                "q3": 0.00158400000000114,
+                "iqr_outliers": 20,
+                "stddev_outliers": 48,
+                "outliers": "48;20",
+                "ld15iqr": 0.0015639999999983445,
+                "hd15iqr": 0.0015980000000013206,
+                "ops": 632.334267915372,
+                "total": 0.5867150000000514,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[2-12]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[2-12]",
+            "params": {
+                "nqubits": 2,
+                "nlayers": 12
+            },
+            "param": "2-12",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.0029140000000005273,
+                "max": 0.003164000000001721,
+                "mean": 0.002940665689149525,
+                "stddev": 3.3799751502924485e-05,
+                "rounds": 341,
+                "median": 0.002929999999999211,
+                "iqr": 1.5000000001208491e-05,
+                "q1": 0.002925999999998652,
+                "q3": 0.0029409999999998604,
+                "iqr_outliers": 30,
+                "stddev_outliers": 24,
+                "outliers": "24;30",
+                "ld15iqr": 0.0029140000000005273,
+                "hd15iqr": 0.0029670000000017183,
+                "ops": 340.0590565904184,
+                "total": 1.002766999999988,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[2-20]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[2-20]",
+            "params": {
+                "nqubits": 2,
+                "nlayers": 20
+            },
+            "param": "2-20",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.004280000000001394,
+                "max": 0.004463999999998691,
+                "mean": 0.004317469827586135,
+                "stddev": 2.8156319121352315e-05,
+                "rounds": 232,
+                "median": 0.004311999999998761,
+                "iqr": 1.8999999994662176e-05,
+                "q1": 0.004301000000005217,
+                "q3": 0.0043199999999998795,
+                "iqr_outliers": 27,
+                "stddev_outliers": 36,
+                "outliers": "36;27",
+                "ld15iqr": 0.004280000000001394,
+                "hd15iqr": 0.004348999999997716,
+                "ops": 231.6171368727532,
+                "total": 1.0016529999999833,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[6-4]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[6-4]",
+            "params": {
+                "nqubits": 6,
+                "nlayers": 4
+            },
+            "param": "6-4",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.0033529999999970528,
+                "max": 0.003555000000005748,
+                "mean": 0.0033930912162162294,
+                "stddev": 2.3421020340358133e-05,
+                "rounds": 296,
+                "median": 0.00338999999999956,
+                "iqr": 2.800000000036107e-05,
+                "q1": 0.0033770000000004075,
+                "q3": 0.0034050000000007685,
+                "iqr_outliers": 6,
+                "stddev_outliers": 66,
+                "outliers": "66;6",
+                "ld15iqr": 0.0033529999999970528,
+                "hd15iqr": 0.0034479999999987854,
+                "ops": 294.71650960068786,
+                "total": 1.0043550000000039,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[6-12]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[6-12]",
+            "params": {
+                "nqubits": 6,
+                "nlayers": 12
+            },
+            "param": "6-12",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.008310999999999069,
+                "max": 0.008473999999999648,
+                "mean": 0.008369512396693887,
+                "stddev": 2.626344598577131e-05,
+                "rounds": 121,
+                "median": 0.008366999999999791,
+                "iqr": 2.39999999980256e-05,
+                "q1": 0.008357000000001946,
+                "q3": 0.008380999999999972,
+                "iqr_outliers": 8,
+                "stddev_outliers": 36,
+                "outliers": "36;8",
+                "ld15iqr": 0.008321999999999719,
+                "hd15iqr": 0.008417000000001451,
+                "ops": 119.48127353213773,
+                "total": 1.0127109999999604,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[6-20]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[6-20]",
+            "params": {
+                "nqubits": 6,
+                "nlayers": 20
+            },
+            "param": "6-20",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.01333299999999582,
+                "max": 0.014473999999999876,
+                "mean": 0.01345649999999983,
+                "stddev": 0.0001971710255926383,
+                "rounds": 76,
+                "median": 0.013393000000000654,
+                "iqr": 5.7999999995672624e-05,
+                "q1": 0.013375000000003467,
+                "q3": 0.01343299999999914,
+                "iqr_outliers": 10,
+                "stddev_outliers": 6,
+                "outliers": "6;10",
+                "ld15iqr": 0.01333299999999582,
+                "hd15iqr": 0.01353499999999741,
+                "ops": 74.31352877791495,
+                "total": 1.0226939999999871,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[10-4]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[10-4]",
+            "params": {
+                "nqubits": 10,
+                "nlayers": 4
+            },
+            "param": "10-4",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.006079999999997199,
+                "max": 0.006494999999993922,
+                "mean": 0.006151810975609481,
+                "stddev": 4.9391210330771654e-05,
+                "rounds": 164,
+                "median": 0.006152000000000157,
+                "iqr": 2.449999999853958e-05,
+                "q1": 0.0061374999999976865,
+                "q3": 0.006161999999996226,
+                "iqr_outliers": 24,
+                "stddev_outliers": 25,
+                "outliers": "25;24",
+                "ld15iqr": 0.0061019999999984975,
+                "hd15iqr": 0.0062130000000024665,
+                "ops": 162.5537592043661,
+                "total": 1.0088969999999549,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[10-12]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[10-12]",
+            "params": {
+                "nqubits": 10,
+                "nlayers": 12
+            },
+            "param": "10-12",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.01643399999999673,
+                "max": 0.03280099999999919,
+                "mean": 0.016806213114754356,
+                "stddev": 0.002086625706052252,
+                "rounds": 61,
+                "median": 0.016511000000001275,
+                "iqr": 4.1000000001290005e-05,
+                "q1": 0.016491749999998362,
+                "q3": 0.016532749999999652,
+                "iqr_outliers": 6,
+                "stddev_outliers": 1,
+                "outliers": "1;6",
+                "ld15iqr": 0.01643399999999673,
+                "hd15iqr": 0.016684999999995398,
+                "ops": 59.50180407518987,
+                "total": 1.0251790000000156,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[10-20]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[10-20]",
+            "params": {
+                "nqubits": 10,
+                "nlayers": 20
+            },
+            "param": "10-20",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.026758000000000948,
+                "max": 0.04307500000000175,
+                "mean": 0.027374736842105188,
+                "stddev": 0.002626847146081663,
+                "rounds": 38,
+                "median": 0.026910999999998353,
+                "iqr": 9.899999999873899e-05,
+                "q1": 0.026859999999999218,
+                "q3": 0.026958999999997957,
+                "iqr_outliers": 3,
+                "stddev_outliers": 1,
+                "outliers": "1;3",
+                "ld15iqr": 0.026758000000000948,
+                "hd15iqr": 0.027258999999993705,
+                "ops": 36.53003153118521,
+                "total": 1.0402399999999972,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[14-4]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[14-4]",
+            "params": {
+                "nqubits": 14,
+                "nlayers": 4
+            },
+            "param": "14-4",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.11679600000000079,
+                "max": 0.2478659999999948,
+                "mean": 0.15756729999999947,
+                "stddev": 0.048003400088026414,
+                "rounds": 10,
+                "median": 0.14240549999999885,
+                "iqr": 0.06597600000000625,
+                "q1": 0.12134299999999598,
+                "q3": 0.18731900000000223,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.11679600000000079,
+                "hd15iqr": 0.2478659999999948,
+                "ops": 6.346494482040393,
+                "total": 1.5756729999999948,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[14-12]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[14-12]",
+            "params": {
+                "nqubits": 14,
+                "nlayers": 12
+            },
+            "param": "14-12",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.3379009999999951,
+                "max": 0.45139300000000304,
+                "mean": 0.3731192000000007,
+                "stddev": 0.046198917765464816,
+                "rounds": 5,
+                "median": 0.36621600000000143,
+                "iqr": 0.0513455000000036,
+                "q1": 0.33927124999999947,
+                "q3": 0.39061675000000307,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.3379009999999951,
+                "hd15iqr": 0.45139300000000304,
+                "ops": 2.6801086623256003,
+                "total": 1.8655960000000036,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[14-20]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[14-20]",
+            "params": {
+                "nqubits": 14,
+                "nlayers": 20
+            },
+            "param": "14-20",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.5286389999999983,
+                "max": 0.6041570000000007,
+                "mean": 0.5787720000000007,
+                "stddev": 0.03149506278768332,
+                "rounds": 5,
+                "median": 0.589185999999998,
+                "iqr": 0.04483550000000491,
+                "q1": 0.5586359999999999,
+                "q3": 0.6034715000000048,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.5286389999999983,
+                "hd15iqr": 0.6041570000000007,
+                "ops": 1.7277960924163551,
+                "total": 2.8938600000000037,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[18-4]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[18-4]",
+            "params": {
+                "nqubits": 18,
+                "nlayers": 4
+            },
+            "param": "18-4",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 2.8914449999999903,
+                "max": 2.9648660000000007,
+                "mean": 2.9334298000000016,
+                "stddev": 0.034943296620385596,
+                "rounds": 5,
+                "median": 2.9532489999999996,
+                "iqr": 0.06205400000000694,
+                "q1": 2.8976077500000024,
+                "q3": 2.9596617500000093,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 2.8914449999999903,
+                "hd15iqr": 2.9648660000000007,
+                "ops": 0.3408978800174456,
+                "total": 14.667149000000009,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[18-12]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[18-12]",
+            "params": {
+                "nqubits": 18,
+                "nlayers": 12
+            },
+            "param": "18-12",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 7.03646999999998,
+                "max": 8.470112,
+                "mean": 7.975976199999991,
+                "stddev": 0.6416561404827422,
+                "rounds": 5,
+                "median": 8.372490999999997,
+                "iqr": 0.9962465000000051,
+                "q1": 7.440502499999987,
+                "q3": 8.436748999999992,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 7.03646999999998,
+                "hd15iqr": 8.470112,
+                "ops": 0.1253765025026029,
+                "total": 39.879880999999955,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[18-20]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[18-20]",
+            "params": {
+                "nqubits": 18,
+                "nlayers": 20
+            },
+            "param": "18-20",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 8.514905999999996,
+                "max": 10.367734999999982,
+                "mean": 9.470765399999994,
+                "stddev": 0.704567240159722,
+                "rounds": 5,
+                "median": 9.631873999999982,
+                "iqr": 0.9787557499999764,
+                "q1": 8.935694250000012,
+                "q3": 9.914449999999988,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 8.514905999999996,
+                "hd15iqr": 10.367734999999982,
+                "ops": 0.10558808689316712,
+                "total": 47.35382699999997,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit_result_types[results0]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit_result_types[results0]",
+            "params": {
+                "results": [
+                    "UNSERIALIZABLE[Expectation(observable=['x'], targets=None, type=<Type.expectation: 'expectation'>)]"
+                ]
+            },
+            "param": "results0",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.03521899999998368,
+                "max": 0.038285999999970954,
+                "mean": 0.03630717241379318,
+                "stddev": 0.0009997372893758472,
+                "rounds": 29,
+                "median": 0.03602499999999509,
+                "iqr": 0.001578999999949815,
+                "q1": 0.03538000000001773,
+                "q3": 0.036958999999967546,
+                "iqr_outliers": 0,
+                "stddev_outliers": 8,
+                "outliers": "8;0",
+                "ld15iqr": 0.03521899999998368,
+                "hd15iqr": 0.038285999999970954,
+                "ops": 27.54276726931502,
+                "total": 1.0529080000000022,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit_result_types[results1]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit_result_types[results1]",
+            "params": {
+                "results": [
+                    "UNSERIALIZABLE[Probability(targets=[0, 1], type=<Type.probability: 'probability'>)]"
+                ]
+            },
+            "param": "results1",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.03447900000003301,
+                "max": 0.03614999999996371,
+                "mean": 0.03481186206896962,
+                "stddev": 0.00038966934005239725,
+                "rounds": 29,
+                "median": 0.034693000000004304,
+                "iqr": 0.0001912500000429418,
+                "q1": 0.03460699999999406,
+                "q3": 0.034798250000037,
+                "iqr_outliers": 4,
+                "stddev_outliers": 4,
+                "outliers": "4;4",
+                "ld15iqr": 0.03447900000003301,
+                "hd15iqr": 0.035213999999996304,
+                "ops": 28.725840577524686,
+                "total": 1.009544000000119,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit_result_types[results2]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit_result_types[results2]",
+            "params": {
+                "results": [
+                    "UNSERIALIZABLE[Probability(targets=None, type=<Type.probability: 'probability'>)]",
+                    "UNSERIALIZABLE[Variance(observable=['x'], targets=None, type=<Type.variance: 'variance'>)]"
+                ]
+            },
+            "param": "results2",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.03679699999997865,
+                "max": 0.05918100000002369,
+                "mean": 0.038162275862066115,
+                "stddev": 0.004083770770617807,
+                "rounds": 29,
+                "median": 0.037286000000051445,
+                "iqr": 0.0009419999999664697,
+                "q1": 0.03690149999999903,
+                "q3": 0.0378434999999655,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.03679699999997865,
+                "hd15iqr": 0.05918100000002369,
+                "ops": 26.203887934105502,
+                "total": 1.1067059999999174,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit_result_types[results3]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit_result_types[results3]",
+            "params": {
+                "results": [
+                    "UNSERIALIZABLE[Variance(observable=['z'], targets=[0], type=<Type.variance: 'variance'>)]"
+                ]
+            },
+            "param": "results3",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.035415999999997894,
+                "max": 0.03873899999996411,
+                "mean": 0.03710049999999602,
+                "stddev": 0.0007843179863416983,
+                "rounds": 28,
+                "median": 0.03715199999999186,
+                "iqr": 0.0009415000000103646,
+                "q1": 0.03651299999998514,
+                "q3": 0.037454499999995505,
+                "iqr_outliers": 0,
+                "stddev_outliers": 7,
+                "outliers": "7;0",
+                "ld15iqr": 0.035415999999997894,
+                "hd15iqr": 0.03873899999996411,
+                "ops": 26.953814638619626,
+                "total": 1.0388139999998884,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_rydberg_simulator[1]",
+            "fullname": "test/performance/test_performance.py::test_rydberg_simulator[1]",
+            "params": {
+                "natoms": 1
+            },
+            "param": "1",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.7664449999999761,
+                "max": 0.782256000000018,
+                "mean": 0.7731951999999864,
+                "stddev": 0.006232324782957374,
+                "rounds": 5,
+                "median": 0.7706829999999627,
+                "iqr": 0.008856250000036425,
+                "q1": 0.7691314999999719,
+                "q3": 0.7779877500000083,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.7664449999999761,
+                "hd15iqr": 0.782256000000018,
+                "ops": 1.293334464569901,
+                "total": 3.8659759999999324,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_rydberg_simulator[3]",
+            "fullname": "test/performance/test_performance.py::test_rydberg_simulator[3]",
+            "params": {
+                "natoms": 3
+            },
+            "param": "3",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.771082999999976,
+                "max": 0.7936559999999986,
+                "mean": 0.7833807999999862,
+                "stddev": 0.009928543709935851,
+                "rounds": 5,
+                "median": 0.7813289999999711,
+                "iqr": 0.0175007499999964,
+                "q1": 0.7759054999999933,
+                "q3": 0.7934062499999897,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.771082999999976,
+                "hd15iqr": 0.7936559999999986,
+                "ops": 1.2765183930982449,
+                "total": 3.9169039999999313,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_rydberg_simulator[5]",
+            "fullname": "test/performance/test_performance.py::test_rydberg_simulator[5]",
+            "params": {
+                "natoms": 5
+            },
+            "param": "5",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 16.70063200000004,
+                "max": 19.05699699999991,
+                "mean": 17.59396039999997,
+                "stddev": 0.9717648986235173,
+                "rounds": 5,
+                "median": 17.086164999999937,
+                "iqr": 1.396185750000086,
+                "q1": 16.943863749999934,
+                "q3": 18.34004950000002,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 16.70063200000004,
+                "hd15iqr": 19.05699699999991,
+                "ops": 0.05683768618690319,
+                "total": 87.96980199999985,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_rydberg_simulator[7]",
+            "fullname": "test/performance/test_performance.py::test_rydberg_simulator[7]",
+            "params": {
+                "natoms": 7
+            },
+            "param": "7",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 57.71092799999997,
+                "max": 104.21762100000001,
+                "mean": 70.06625680000002,
+                "stddev": 20.080259305297034,
+                "rounds": 5,
+                "median": 58.18121000000019,
+                "iqr": 22.418818500000214,
+                "q1": 57.86473124999986,
+                "q3": 80.28354975000008,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 57.71092799999997,
+                "hd15iqr": 104.21762100000001,
+                "ops": 0.014272205276420586,
+                "total": 350.3312840000001,
+                "iterations": 1
+            }
+        }
+    ],
+    "datetime": "2023-04-15T18:15:50.065164",
+    "version": "3.4.1"
+}

--- a/test/.benchmarks/Darwin-CPython-3.9-64bit/0002_e09fe39b7d0b877e70e15e6d4aa27c25eb54654b_20230415_181551.json
+++ b/test/.benchmarks/Darwin-CPython-3.9-64bit/0002_e09fe39b7d0b877e70e15e6d4aa27c25eb54654b_20230415_181551.json
@@ -1,0 +1,1171 @@
+{
+    "machine_info": {
+        "node": "pweinbergmac.local",
+        "processor": "i386",
+        "machine": "x86_64",
+        "python_compiler": "Clang 14.0.6 ",
+        "python_implementation": "CPython",
+        "python_implementation_version": "3.9.16",
+        "python_version": "3.9.16",
+        "python_build": [
+            "main",
+            "Mar  8 2023 04:29:44"
+        ],
+        "release": "21.6.0",
+        "system": "Darwin",
+        "cpu": {
+            "python_version": "3.9.16.final.0 (64 bit)",
+            "cpuinfo_version": [
+                8,
+                0,
+                0
+            ],
+            "cpuinfo_version_string": "8.0.0",
+            "arch": "X86_64",
+            "bits": 64,
+            "count": 10,
+            "arch_string_raw": "x86_64",
+            "brand_raw": "Apple M1 Pro",
+            "hz_actual_friendly": "2.4000 GHz",
+            "hz_actual": [
+                2400000000,
+                0
+            ],
+            "family": 6,
+            "flags": [
+                "acpi",
+                "aes",
+                "apic",
+                "clflush",
+                "clfsh",
+                "cmov",
+                "cx16",
+                "cx8",
+                "de",
+                "ds",
+                "dscpl",
+                "dtes64",
+                "dtse64",
+                "est",
+                "fpu",
+                "fxsr",
+                "htt",
+                "lahf_lm",
+                "mca",
+                "mce",
+                "mmx",
+                "mon",
+                "monitor",
+                "msr",
+                "mtrr",
+                "pae",
+                "pat",
+                "pbe",
+                "pclmulqdq",
+                "pdcm",
+                "pge",
+                "pni",
+                "popcnt",
+                "pse",
+                "pse36",
+                "seglim64",
+                "sep",
+                "ss",
+                "sse",
+                "sse2",
+                "sse3",
+                "sse4.1",
+                "sse4.2",
+                "sse4_1",
+                "sse4_2",
+                "ssse3",
+                "tm",
+                "tm2",
+                "tpr",
+                "tsc",
+                "vme",
+                "vmx"
+            ],
+            "vendor_id_raw": "GenuineIntel",
+            "hz_advertised_friendly": "2.5000 GHz",
+            "hz_advertised": [
+                2500000000,
+                0
+            ],
+            "l2_cache_size": 65536,
+            "l2_cache_line_size": 8192,
+            "l2_cache_associativity": 8,
+            "model": 44
+        }
+    },
+    "commit_info": {
+        "id": "e09fe39b7d0b877e70e15e6d4aa27c25eb54654b",
+        "time": "2023-04-15T14:06:57-04:00",
+        "author_time": "2023-04-15T14:06:57-04:00",
+        "dirty": false,
+        "project": "amazon-braket-default-simulator-python",
+        "branch": "benchmarks-branch"
+    },
+    "benchmarks": [
+        {
+            "group": null,
+            "name": "test_grcs_simulation",
+            "fullname": "test/performance/test_performance.py::test_grcs_simulation",
+            "params": null,
+            "param": null,
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.3150119999999994,
+                "max": 0.4039850000000005,
+                "mean": 0.3584455999999999,
+                "stddev": 0.032460870572121346,
+                "rounds": 5,
+                "median": 0.35442399999999985,
+                "iqr": 0.038554999999998785,
+                "q1": 0.3401497500000006,
+                "q3": 0.37870474999999937,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.3150119999999994,
+                "hd15iqr": 0.4039850000000005,
+                "ops": 2.7898236161916903,
+                "total": 1.7922279999999997,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_qft[4]",
+            "fullname": "test/performance/test_performance.py::test_qft[4]",
+            "params": {
+                "nqubits": 4
+            },
+            "param": "4",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.0013129999999996755,
+                "max": 0.0017689999999994654,
+                "mean": 0.0013423183183182326,
+                "stddev": 4.382420585532456e-05,
+                "rounds": 333,
+                "median": 0.0013329999999989184,
+                "iqr": 9.999999999621423e-06,
+                "q1": 0.0013290000000001356,
+                "q3": 0.001338999999999757,
+                "iqr_outliers": 31,
+                "stddev_outliers": 17,
+                "outliers": "17;31",
+                "ld15iqr": 0.0013199999999997658,
+                "hd15iqr": 0.0013540000000009655,
+                "ops": 744.979775924449,
+                "total": 0.4469919999999714,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_qft[8]",
+            "fullname": "test/performance/test_performance.py::test_qft[8]",
+            "params": {
+                "nqubits": 8
+            },
+            "param": "8",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.0023900000000001143,
+                "max": 0.002653999999999712,
+                "mean": 0.0024154114832536044,
+                "stddev": 2.2839615173986227e-05,
+                "rounds": 418,
+                "median": 0.0024100000000011335,
+                "iqr": 1.1000000002425736e-05,
+                "q1": 0.002405999999998798,
+                "q3": 0.0024170000000012237,
+                "iqr_outliers": 31,
+                "stddev_outliers": 33,
+                "outliers": "33;31",
+                "ld15iqr": 0.0023900000000001143,
+                "hd15iqr": 0.002433999999999159,
+                "ops": 414.00813357605693,
+                "total": 1.0096420000000066,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_qft[12]",
+            "fullname": "test/performance/test_performance.py::test_qft[12]",
+            "params": {
+                "nqubits": 12
+            },
+            "param": "12",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.006350000000001188,
+                "max": 0.006752999999999787,
+                "mean": 0.006431816455696229,
+                "stddev": 7.827738027361899e-05,
+                "rounds": 158,
+                "median": 0.0064104999999994305,
+                "iqr": 7.000000000445539e-05,
+                "q1": 0.006374999999998465,
+                "q3": 0.006445000000002921,
+                "iqr_outliers": 19,
+                "stddev_outliers": 26,
+                "outliers": "26;19",
+                "ld15iqr": 0.006350000000001188,
+                "hd15iqr": 0.006551999999999225,
+                "ops": 155.47707352786273,
+                "total": 1.0162270000000042,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_qft[16]",
+            "fullname": "test/performance/test_performance.py::test_qft[16]",
+            "params": {
+                "nqubits": 16
+            },
+            "param": "16",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.478591999999999,
+                "max": 0.5946350000000002,
+                "mean": 0.5089913999999993,
+                "stddev": 0.04843855200457632,
+                "rounds": 5,
+                "median": 0.4900599999999997,
+                "iqr": 0.04005974999999928,
+                "q1": 0.48224974999999937,
+                "q3": 0.5223094999999986,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.478591999999999,
+                "hd15iqr": 0.5946350000000002,
+                "ops": 1.9646697370525343,
+                "total": 2.5449569999999966,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[2-4]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[2-4]",
+            "params": {
+                "nqubits": 2,
+                "nlayers": 4
+            },
+            "param": "2-4",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.0015590000000003101,
+                "max": 0.0021039999999992176,
+                "mean": 0.0016063944954128853,
+                "stddev": 4.0475454369385285e-05,
+                "rounds": 436,
+                "median": 0.0015935000000002475,
+                "iqr": 2.1499999999008423e-05,
+                "q1": 0.0015880000000016992,
+                "q3": 0.0016095000000007076,
+                "iqr_outliers": 43,
+                "stddev_outliers": 39,
+                "outliers": "39;43",
+                "ld15iqr": 0.0015590000000003101,
+                "hd15iqr": 0.0016420000000003654,
+                "ops": 622.5120932968423,
+                "total": 0.700388000000018,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[2-12]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[2-12]",
+            "params": {
+                "nqubits": 2,
+                "nlayers": 12
+            },
+            "param": "2-12",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.00292699999999968,
+                "max": 0.0036269999999980485,
+                "mean": 0.0030282595870206467,
+                "stddev": 0.00011828647349410533,
+                "rounds": 339,
+                "median": 0.0029900000000004923,
+                "iqr": 5.8500000000627495e-05,
+                "q1": 0.002960250000000997,
+                "q3": 0.0030187500000016243,
+                "iqr_outliers": 48,
+                "stddev_outliers": 40,
+                "outliers": "40;48",
+                "ld15iqr": 0.00292699999999968,
+                "hd15iqr": 0.00311100000000053,
+                "ops": 330.22268113542077,
+                "total": 1.0265799999999992,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[2-20]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[2-20]",
+            "params": {
+                "nqubits": 2,
+                "nlayers": 20
+            },
+            "param": "2-20",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.004251000000000005,
+                "max": 0.0047560000000004266,
+                "mean": 0.004387795652173835,
+                "stddev": 6.912558647776727e-05,
+                "rounds": 230,
+                "median": 0.004382500000000178,
+                "iqr": 6.099999999875649e-05,
+                "q1": 0.0043480000000002406,
+                "q3": 0.004408999999998997,
+                "iqr_outliers": 15,
+                "stddev_outliers": 43,
+                "outliers": "43;15",
+                "ld15iqr": 0.004256999999999067,
+                "hd15iqr": 0.004501999999998674,
+                "ops": 227.90487052526532,
+                "total": 1.009192999999982,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[6-4]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[6-4]",
+            "params": {
+                "nqubits": 6,
+                "nlayers": 4
+            },
+            "param": "6-4",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.003363000000000227,
+                "max": 0.004049999999999443,
+                "mean": 0.003534916387959976,
+                "stddev": 0.00015811930452057515,
+                "rounds": 299,
+                "median": 0.00345999999999691,
+                "iqr": 0.0001639999999980546,
+                "q1": 0.0034330000000011296,
+                "q3": 0.003596999999999184,
+                "iqr_outliers": 28,
+                "stddev_outliers": 58,
+                "outliers": "58;28",
+                "ld15iqr": 0.003363000000000227,
+                "hd15iqr": 0.0038430000000033715,
+                "ops": 282.892122542425,
+                "total": 1.0569400000000329,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[6-12]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[6-12]",
+            "params": {
+                "nqubits": 6,
+                "nlayers": 12
+            },
+            "param": "6-12",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.008313000000001125,
+                "max": 0.009067999999999188,
+                "mean": 0.00853701680672248,
+                "stddev": 0.00011512255689015053,
+                "rounds": 119,
+                "median": 0.008523000000003833,
+                "iqr": 7.34999999973951e-05,
+                "q1": 0.00848900000000441,
+                "q3": 0.008562500000001805,
+                "iqr_outliers": 12,
+                "stddev_outliers": 20,
+                "outliers": "20;12",
+                "ld15iqr": 0.008380000000002497,
+                "hd15iqr": 0.008688999999996838,
+                "ops": 117.13693701675147,
+                "total": 1.0159049999999752,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[6-20]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[6-20]",
+            "params": {
+                "nqubits": 6,
+                "nlayers": 20
+            },
+            "param": "6-20",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.013246999999999787,
+                "max": 0.01381200000000149,
+                "mean": 0.0135014210526314,
+                "stddev": 0.0001350046185041868,
+                "rounds": 76,
+                "median": 0.013522999999995733,
+                "iqr": 0.00020899999999812735,
+                "q1": 0.013390000000001123,
+                "q3": 0.01359899999999925,
+                "iqr_outliers": 0,
+                "stddev_outliers": 28,
+                "outliers": "28;0",
+                "ld15iqr": 0.013246999999999787,
+                "hd15iqr": 0.01381200000000149,
+                "ops": 74.06627762379887,
+                "total": 1.0261079999999865,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[10-4]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[10-4]",
+            "params": {
+                "nqubits": 10,
+                "nlayers": 4
+            },
+            "param": "10-4",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.006168999999999869,
+                "max": 0.0070010000000024775,
+                "mean": 0.006508630303030206,
+                "stddev": 0.0002155944200442371,
+                "rounds": 165,
+                "median": 0.006543000000000632,
+                "iqr": 0.00039775000000119576,
+                "q1": 0.006289000000000655,
+                "q3": 0.006686750000001851,
+                "iqr_outliers": 0,
+                "stddev_outliers": 76,
+                "outliers": "76;0",
+                "ld15iqr": 0.006168999999999869,
+                "hd15iqr": 0.0070010000000024775,
+                "ops": 153.6421571731356,
+                "total": 1.073923999999984,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[10-12]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[10-12]",
+            "params": {
+                "nqubits": 10,
+                "nlayers": 12
+            },
+            "param": "10-12",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.016392000000003293,
+                "max": 0.03127699999999578,
+                "mean": 0.01678336065573765,
+                "stddev": 0.0019021948816453243,
+                "rounds": 61,
+                "median": 0.016491000000002032,
+                "iqr": 5.7250000001118906e-05,
+                "q1": 0.016467750000000336,
+                "q3": 0.016525000000001455,
+                "iqr_outliers": 6,
+                "stddev_outliers": 1,
+                "outliers": "1;6",
+                "ld15iqr": 0.016392000000003293,
+                "hd15iqr": 0.016618000000001132,
+                "ops": 59.5828225652849,
+                "total": 1.0237849999999966,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[10-20]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[10-20]",
+            "params": {
+                "nqubits": 10,
+                "nlayers": 20
+            },
+            "param": "10-20",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.026921000000001527,
+                "max": 0.031142000000002668,
+                "mean": 0.028150500000000165,
+                "stddev": 0.000983414013334298,
+                "rounds": 38,
+                "median": 0.02811850000000149,
+                "iqr": 0.0013980000000017867,
+                "q1": 0.02732199999999807,
+                "q3": 0.028719999999999857,
+                "iqr_outliers": 1,
+                "stddev_outliers": 10,
+                "outliers": "10;1",
+                "ld15iqr": 0.026921000000001527,
+                "hd15iqr": 0.031142000000002668,
+                "ops": 35.52334772028895,
+                "total": 1.0697190000000063,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[14-4]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[14-4]",
+            "params": {
+                "nqubits": 14,
+                "nlayers": 4
+            },
+            "param": "14-4",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.10966599999999715,
+                "max": 0.12741100000000216,
+                "mean": 0.11891858333333379,
+                "stddev": 0.005278136128638513,
+                "rounds": 12,
+                "median": 0.11775749999999974,
+                "iqr": 0.00747050000000371,
+                "q1": 0.11541849999999698,
+                "q3": 0.12288900000000069,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.10966599999999715,
+                "hd15iqr": 0.12741100000000216,
+                "ops": 8.409114639357567,
+                "total": 1.4270230000000055,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[14-12]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[14-12]",
+            "params": {
+                "nqubits": 14,
+                "nlayers": 12
+            },
+            "param": "14-12",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.31827600000000444,
+                "max": 0.44557600000000264,
+                "mean": 0.36740000000000067,
+                "stddev": 0.050426992632914176,
+                "rounds": 5,
+                "median": 0.36417000000000144,
+                "iqr": 0.07011249999999691,
+                "q1": 0.32629200000000047,
+                "q3": 0.3964044999999974,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.31827600000000444,
+                "hd15iqr": 0.44557600000000264,
+                "ops": 2.7218290691344533,
+                "total": 1.8370000000000033,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[14-20]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[14-20]",
+            "params": {
+                "nqubits": 14,
+                "nlayers": 20
+            },
+            "param": "14-20",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.5179930000000041,
+                "max": 0.5728969999999975,
+                "mean": 0.5545869999999951,
+                "stddev": 0.02120966368191213,
+                "rounds": 5,
+                "median": 0.5604319999999916,
+                "iqr": 0.01762224999999873,
+                "q1": 0.5481549999999942,
+                "q3": 0.5657772499999929,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.5582089999999909,
+                "hd15iqr": 0.5728969999999975,
+                "ops": 1.8031436005532204,
+                "total": 2.7729349999999755,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[18-4]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[18-4]",
+            "params": {
+                "nqubits": 18,
+                "nlayers": 4
+            },
+            "param": "18-4",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 2.762664000000001,
+                "max": 2.870706999999996,
+                "mean": 2.8282598000000005,
+                "stddev": 0.043580858214355735,
+                "rounds": 5,
+                "median": 2.842918999999995,
+                "iqr": 0.0643854999999931,
+                "q1": 2.7963570000000075,
+                "q3": 2.8607425000000006,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 2.762664000000001,
+                "hd15iqr": 2.870706999999996,
+                "ops": 0.35357430742395013,
+                "total": 14.141299000000004,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[18-12]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[18-12]",
+            "params": {
+                "nqubits": 18,
+                "nlayers": 12
+            },
+            "param": "18-12",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 5.992118000000005,
+                "max": 8.595541999999995,
+                "mean": 7.797926200000006,
+                "stddev": 1.0970071877363432,
+                "rounds": 5,
+                "median": 8.294949000000003,
+                "iqr": 1.4294745000000049,
+                "q1": 7.148853500000008,
+                "q3": 8.578328000000013,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 5.992118000000005,
+                "hd15iqr": 8.595541999999995,
+                "ops": 0.1282392233976258,
+                "total": 38.98963100000003,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit[18-20]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit[18-20]",
+            "params": {
+                "nqubits": 18,
+                "nlayers": 20
+            },
+            "param": "18-20",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 13.987333999999976,
+                "max": 14.353594999999984,
+                "mean": 14.1683092,
+                "stddev": 0.13018150893925312,
+                "rounds": 5,
+                "median": 14.159955999999966,
+                "iqr": 0.11814749999999208,
+                "q1": 14.111290250000025,
+                "q3": 14.229437750000017,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 13.987333999999976,
+                "hd15iqr": 14.353594999999984,
+                "ops": 0.07058005199378342,
+                "total": 70.841546,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit_result_types[results0]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit_result_types[results0]",
+            "params": {
+                "results": [
+                    "UNSERIALIZABLE[Expectation(observable=['x'], targets=None, type=<Type.expectation: 'expectation'>)]"
+                ]
+            },
+            "param": "results0",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.034863999999970474,
+                "max": 0.039387999999974,
+                "mean": 0.036863896551718144,
+                "stddev": 0.0013454542340980685,
+                "rounds": 29,
+                "median": 0.0373819999999796,
+                "iqr": 0.0026484999999638603,
+                "q1": 0.03516900000002465,
+                "q3": 0.03781749999998851,
+                "iqr_outliers": 0,
+                "stddev_outliers": 12,
+                "outliers": "12;0",
+                "ld15iqr": 0.034863999999970474,
+                "hd15iqr": 0.039387999999974,
+                "ops": 27.126812234757974,
+                "total": 1.0690529999998262,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit_result_types[results1]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit_result_types[results1]",
+            "params": {
+                "results": [
+                    "UNSERIALIZABLE[Probability(targets=[0, 1], type=<Type.probability: 'probability'>)]"
+                ]
+            },
+            "param": "results1",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.0341940000000136,
+                "max": 0.03836300000000392,
+                "mean": 0.034741933333335355,
+                "stddev": 0.000994143919828296,
+                "rounds": 30,
+                "median": 0.034339000000016995,
+                "iqr": 0.00024200000001428634,
+                "q1": 0.0342939999999885,
+                "q3": 0.03453600000000279,
+                "iqr_outliers": 6,
+                "stddev_outliers": 4,
+                "outliers": "4;6",
+                "ld15iqr": 0.0341940000000136,
+                "hd15iqr": 0.03491300000001729,
+                "ops": 28.783660091837387,
+                "total": 1.0422580000000607,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit_result_types[results2]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit_result_types[results2]",
+            "params": {
+                "results": [
+                    "UNSERIALIZABLE[Probability(targets=None, type=<Type.probability: 'probability'>)]",
+                    "UNSERIALIZABLE[Variance(observable=['x'], targets=None, type=<Type.variance: 'variance'>)]"
+                ]
+            },
+            "param": "results2",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.03514999999998736,
+                "max": 0.03825499999999238,
+                "mean": 0.0363056551724079,
+                "stddev": 0.0009141606718654179,
+                "rounds": 29,
+                "median": 0.03601999999995087,
+                "iqr": 0.0016387499999552801,
+                "q1": 0.03550775000000783,
+                "q3": 0.03714649999996311,
+                "iqr_outliers": 0,
+                "stddev_outliers": 12,
+                "outliers": "12;0",
+                "ld15iqr": 0.03514999999998736,
+                "hd15iqr": 0.03825499999999238,
+                "ops": 27.543918302843206,
+                "total": 1.052863999999829,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_layered_continuous_gates_circuit_result_types[results3]",
+            "fullname": "test/performance/test_performance.py::test_layered_continuous_gates_circuit_result_types[results3]",
+            "params": {
+                "results": [
+                    "UNSERIALIZABLE[Variance(observable=['z'], targets=[0], type=<Type.variance: 'variance'>)]"
+                ]
+            },
+            "param": "results3",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.03610300000002553,
+                "max": 0.0414679999999521,
+                "mean": 0.0375517666666705,
+                "stddev": 0.001230828027515968,
+                "rounds": 30,
+                "median": 0.03740850000002638,
+                "iqr": 0.0008909999999673346,
+                "q1": 0.03682000000003427,
+                "q3": 0.037711000000001604,
+                "iqr_outliers": 2,
+                "stddev_outliers": 5,
+                "outliers": "5;2",
+                "ld15iqr": 0.03610300000002553,
+                "hd15iqr": 0.04142699999999877,
+                "ops": 26.62990556147553,
+                "total": 1.126553000000115,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_rydberg_simulator[1]",
+            "fullname": "test/performance/test_performance.py::test_rydberg_simulator[1]",
+            "params": {
+                "natoms": 1
+            },
+            "param": "1",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.7827850000000467,
+                "max": 0.8036669999999617,
+                "mean": 0.7916165999999976,
+                "stddev": 0.008579150004492053,
+                "rounds": 5,
+                "median": 0.7901309999999739,
+                "iqr": 0.013933999999977686,
+                "q1": 0.7844020000000143,
+                "q3": 0.7983359999999919,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.7827850000000467,
+                "hd15iqr": 0.8036669999999617,
+                "ops": 1.2632377845537892,
+                "total": 3.958082999999988,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_rydberg_simulator[3]",
+            "fullname": "test/performance/test_performance.py::test_rydberg_simulator[3]",
+            "params": {
+                "natoms": 3
+            },
+            "param": "3",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 0.7862440000000106,
+                "max": 0.8114020000000437,
+                "mean": 0.7972630000000095,
+                "stddev": 0.009768178770905979,
+                "rounds": 5,
+                "median": 0.7985510000000318,
+                "iqr": 0.013711500000027854,
+                "q1": 0.7891442499999783,
+                "q3": 0.8028557500000062,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.7862440000000106,
+                "hd15iqr": 0.8114020000000437,
+                "ops": 1.2542912439182405,
+                "total": 3.9863150000000473,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_rydberg_simulator[5]",
+            "fullname": "test/performance/test_performance.py::test_rydberg_simulator[5]",
+            "params": {
+                "natoms": 5
+            },
+            "param": "5",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 17.353060000000028,
+                "max": 19.984285999999997,
+                "mean": 18.101440000000025,
+                "stddev": 1.0815290304450698,
+                "rounds": 5,
+                "median": 17.77506900000003,
+                "iqr": 1.055535249999906,
+                "q1": 17.412445000000076,
+                "q3": 18.467980249999982,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 17.353060000000028,
+                "hd15iqr": 19.984285999999997,
+                "ops": 0.05524422366397362,
+                "total": 90.50720000000013,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_rydberg_simulator[7]",
+            "fullname": "test/performance/test_performance.py::test_rydberg_simulator[7]",
+            "params": {
+                "natoms": 7
+            },
+            "param": "7",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "process_time",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": 100
+            },
+            "stats": {
+                "min": 61.60221300000012,
+                "max": 67.57955300000003,
+                "mean": 64.64092240000005,
+                "stddev": 2.3387261702143953,
+                "rounds": 5,
+                "median": 64.37114800000018,
+                "iqr": 3.580382000000043,
+                "q1": 62.97691649999996,
+                "q3": 66.5572985,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 61.60221300000012,
+                "hd15iqr": 67.57955300000003,
+                "ops": 0.0154700762747779,
+                "total": 323.2046120000002,
+                "iterations": 1
+            }
+        }
+    ],
+    "datetime": "2023-04-15T18:20:15.413163",
+    "version": "3.4.1"
+}

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_dicts_ops.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_dicts_ops.py
@@ -207,7 +207,9 @@ def test_get_detuning_dict_configurations_3_6():
         {(1, 1): 1, (2, 2): 1, (3, 3): 2, (6, 6): 2, (7, 7): 3, (4, 4): 1, (5, 5): 2}
     )
 
+
 configurations_4 = ["gg", "gr", "rg"]
+
 
 @pytest.mark.parametrize("para", [[program_1, rydberg_interaction_coef, configurations_4]])
 def test_get_interaction_dict_setup_4(para):

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_dicts_ops.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_get_dicts_ops.py
@@ -206,3 +206,36 @@ def test_get_detuning_dict_configurations_3_6():
     assert _get_detuning_dict((0, 1, 2), configurations_3) == dict(
         {(1, 1): 1, (2, 2): 1, (3, 3): 2, (6, 6): 2, (7, 7): 3, (4, 4): 1, (5, 5): 2}
     )
+
+configurations_4 = ["gg", "gr", "rg"]
+
+@pytest.mark.parametrize("para", [[program_1, rydberg_interaction_coef, configurations_4]])
+def test_get_interaction_dict_setup_4(para):
+    program, rydberg_interaction_coef, configurations = para[0], para[1], para[2]
+    interaction = _get_interaction_dict(program, rydberg_interaction_coef, configurations)
+
+    assert interaction == dict()
+
+
+def test_get_detuning_dict_configurations_4_1():
+    assert _get_detuning_dict((0,), configurations_4) == dict({(2, 2): 1})
+
+
+def test_get_detuning_dict_configurations_4_2():
+    assert _get_detuning_dict((1,), configurations_4) == dict({(1, 1): 1})
+
+
+def test_get_detuning_dict_configurations_4_3():
+    assert _get_detuning_dict((0, 1), configurations_4) == dict({(1, 1): 1, (2, 2): 1})
+
+
+def test_get_rabi_dict_configurations_4_1():
+    assert _get_rabi_dict((0,), configurations_4) == dict({(2, 0): 1})
+
+
+def test_get_rabi_dict_configurations_4_2():
+    assert _get_rabi_dict((1,), configurations_4) == dict({(1, 0): 1})
+
+
+def test_get_rabi_dict_configurations_4_3():
+    assert _get_rabi_dict((0, 1), configurations_4) == dict({(1, 0): 1, (2, 0): 1})


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

changed the implementation of `get_rabi_dict` based on the proposal in PR #152. Intead of using a new configuration the dictionary is created when the rabi term is constructed since this only happens a few times. 

*Testing done:*

unit tests are passing. new unit tests required for full code coverage which is added. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
