### PR TITLE
fix: flip internal mapping for ctrl/negctrl

### DIFF
--- a/src/braket/default_simulator/openqasm/program_context.py
+++ b/src/braket/default_simulator/openqasm/program_context.py
@@ -561,8 +561,8 @@ class ProgramContext:
             power *= -1  # todo: replace with adjoint
 
         ctrl_mod_map = {
-            GateModifierName.ctrl: 0,
-            GateModifierName.negctrl: 1,
+            GateModifierName.negctrl: 0,
+            GateModifierName.ctrl: 1,
         }
         ctrl_modifiers = []
         for mod in modifiers:

--- a/src/braket/default_simulator/simulation_strategies/single_operation_strategy.py
+++ b/src/braket/default_simulator/simulation_strategies/single_operation_strategy.py
@@ -38,7 +38,7 @@ def apply_operations(
         matrix = operation.matrix
         all_targets = operation.targets
         num_ctrl = len(operation._ctrl_modifiers)
-        control_state = tuple(np.logical_not(operation._ctrl_modifiers).astype(int))
+        control_state = operation._ctrl_modifiers
         controls = all_targets[:num_ctrl]
         targets = all_targets[num_ctrl:]
         state = multiply_matrix(state, matrix, targets, controls, control_state)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Align internal mapping of ctrl/negctrl with state being controlled on

*Testing done:*

regression testing

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
