### PR TITLE
fix: fix index time clamping bug

### DIFF
--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -499,8 +499,8 @@ def _get_hamiltonian(
 
     # If the integrator uses intermediate time value that is larger than the maximum
     # time value specified, the final time value is used as an approximation.
-    # Currently there is only one driving field. If there are more than one driving 
-    # fields, we assume that they have the same number of coefficients 
+    # Currently there is only one driving field. If there are more than one driving
+    # fields, we assume that they have the same number of coefficients
     if index_time >= len(rabi_coefs[0]):
         index_time = len(rabi_coefs[0]) - 1
         warnings.warn(
@@ -586,8 +586,8 @@ def _apply_hamiltonian(
 
     # If the integrator uses intermediate time value that is larger than the maximum
     # time value specified, the final time value is used as an approximation.
-    # Currently there is only one driving field. If there are more than one driving 
-    # fields, we assume that they have the same number of coefficients 
+    # Currently there is only one driving field. If there are more than one driving
+    # fields, we assume that they have the same number of coefficients
     if index_time >= len(rabi_coefs[0]):
         index_time = len(rabi_coefs[0]) - 1
         warnings.warn(

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -495,20 +495,27 @@ def _get_hamiltonian(
         interaction_op,
     ) = operators_coefficients
 
-    hamiltonian = interaction_op
-
-    # If the driving field is empty, return the interaction operator
-    if len(rabi_coefs) == 0:
-        return hamiltonian
-
     index_time = int(index_time)
+
+    if len(rabi_coefs) > 0:
+        # If there is driving field, the maximum of index_time is the maximum time index
+        # for the driving field.
+        # Note that, if there is more than one driving field, we assume that they have the
+        # same number of coefficients
+        max_index_time = len(rabi_coefs[0]) - 1
+    else:
+        # If there is no driving field, then the maxium of index_time is the maxium time
+        # index for the shifting field.
+        # Note that, if there is more than one shifting field, we assume that they have the
+        # same number of coefficients
+        # Note that, if there is no driving field nor shifting field, the initial state will
+        # be returned, and the simulation would not reach here.
+        max_index_time = len(local_detuing_coefs[0]) - 1
 
     # If the integrator uses intermediate time value that is larger than the maximum
     # time value specified, the final time value is used as an approximation.
-    # Currently there is only one driving field. If there are more than one driving
-    # fields, we assume that they have the same number of coefficients
-    if index_time >= len(rabi_coefs[0]):
-        index_time = len(rabi_coefs[0]) - 1
+    if index_time > max_index_time:
+        index_time = max_index_time
         warnings.warn(
             "The solver uses intermediate time value that is "
             "larger than the maximum time value specified. "
@@ -526,6 +533,8 @@ def _get_hamiltonian(
             "The first time value of the specified range "
             "is used as an approximation."
         )
+
+    hamiltonian = interaction_op
 
     # Add the driving fields
     for rabi_op, rabi_coef, detuning_op, detuning_coef in zip(
@@ -586,18 +595,27 @@ def _apply_hamiltonian(
         interaction_op,
     ) = operators_coefficients
 
-    # If the driving field is empty, return the input register
-    if len(rabi_coefs) == 0:
-        return input_register
-
     index_time = int(index_time)
+
+    if len(rabi_coefs) > 0:
+        # If there is driving field, the maximum of index_time is the maximum time index
+        # for the driving field.
+        # Note that, if there is more than one driving field, we assume that they have the
+        # same number of coefficients
+        max_index_time = len(rabi_coefs[0]) - 1
+    else:
+        # If there is no driving field, then the maxium of index_time is the maxium time
+        # index for the shifting field.
+        # Note that, if there is more than one shifting field, we assume that they have the
+        # same number of coefficients
+        # Note that, if there is no driving field nor shifting field, the initial state will
+        # be returned, and the simulation would not reach here.
+        max_index_time = len(local_detuing_coefs[0]) - 1
 
     # If the integrator uses intermediate time value that is larger than the maximum
     # time value specified, the final time value is used as an approximation.
-    # Currently there is only one driving field. If there are more than one driving
-    # fields, we assume that they have the same number of coefficients
-    if index_time >= len(rabi_coefs[0]):
-        index_time = len(rabi_coefs[0]) - 1
+    if index_time > max_index_time:
+        index_time = max_index_time
         warnings.warn(
             "The solver uses intermediate time value that is "
             "larger than the maximum time value specified. "

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -499,8 +499,10 @@ def _get_hamiltonian(
 
     # If the integrator uses intermediate time value that is larger than the maximum
     # time value specified, the final time value is used as an approximation.
-    if index_time >= len(rabi_coefs):
-        index_time = len(rabi_coefs) - 1
+    # Currently there is only one driving field. If there are more than one driving 
+    # fields, we assume that they have the same number of coefficients 
+    if index_time >= len(rabi_coefs[0]):
+        index_time = len(rabi_coefs[0]) - 1
         warnings.warn(
             "The solver uses intermediate time value that is "
             "larger than the maximum time value specified. "
@@ -584,8 +586,10 @@ def _apply_hamiltonian(
 
     # If the integrator uses intermediate time value that is larger than the maximum
     # time value specified, the final time value is used as an approximation.
-    if index_time >= len(rabi_coefs):
-        index_time = len(rabi_coefs) - 1
+    # Currently there is only one driving field. If there are more than one driving 
+    # fields, we assume that they have the same number of coefficients 
+    if index_time >= len(rabi_coefs[0]):
+        index_time = len(rabi_coefs[0]) - 1
         warnings.warn(
             "The solver uses intermediate time value that is "
             "larger than the maximum time value specified. "

--- a/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
+++ b/src/braket/analog_hamiltonian_simulator/rydberg/rydberg_simulator_helpers.py
@@ -495,6 +495,12 @@ def _get_hamiltonian(
         interaction_op,
     ) = operators_coefficients
 
+    hamiltonian = interaction_op
+
+    # If the driving field is empty, return the interaction operator
+    if len(rabi_coefs) == 0:
+        return hamiltonian
+
     index_time = int(index_time)
 
     # If the integrator uses intermediate time value that is larger than the maximum
@@ -520,8 +526,6 @@ def _get_hamiltonian(
             "The first time value of the specified range "
             "is used as an approximation."
         )
-
-    hamiltonian = interaction_op
 
     # Add the driving fields
     for rabi_op, rabi_coef, detuning_op, detuning_coef in zip(
@@ -581,6 +585,10 @@ def _apply_hamiltonian(
         local_detuing_coefs,
         interaction_op,
     ) = operators_coefficients
+
+    # If the driving field is empty, return the input register
+    if len(rabi_coefs) == 0:
+        return input_register
 
     index_time = int(index_time)
 

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_rydberg_simulator.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_rydberg_simulator.py
@@ -180,13 +180,41 @@ zero_program = convert_unit(
 )
 
 
-def test_scipy_run_for_large_system():
-    result = device.run(zero_program, steps=1)
-    assert isinstance(result, AnalogHamiltonianSimulationTaskResult)
+zero_program_2 = convert_unit(
+    Program(
+        setup={
+            "ahs_register": {
+                "sites": [[0, i * a] for i in range(11)],
+                "filling": [1 for _ in range(11)],
+            }
+        },
+        hamiltonian={
+            "drivingFields": [],
+            "shiftingFields": [
+                {
+                    "magnitude": {
+                        "time_series": {
+                            "times": [0, duration * 1e-06],
+                            "values": [detuning_2 * 1e6, detuning_2 * 1e6],
+                        },
+                        "pattern": [1.0 for _ in range(11)],
+                    }
+                }
+            ],
+        },
+    )
+)
 
 
-def test_scipy_run_for_empty_program():
-    result = device.run(empty_program, steps=2)
+@pytest.mark.parametrize(
+    "program, steps",
+    [
+        (zero_program, 1),
+        (zero_program_2, 4),
+    ],
+)
+def test_scipy_run_for_large_system(program, steps):
+    result = device.run(program, steps=steps)
     assert isinstance(result, AnalogHamiltonianSimulationTaskResult)
 
 

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_rydberg_simulator.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_rydberg_simulator.py
@@ -162,7 +162,7 @@ zero_field = {
 }
 
 
-zero_program = convert_unit(
+big_program_with_only_driving_field = convert_unit(
     Program(
         setup={
             "ahs_register": {
@@ -180,7 +180,7 @@ zero_program = convert_unit(
 )
 
 
-zero_program_2 = convert_unit(
+big_program_with_only_shifting_field = convert_unit(
     Program(
         setup={
             "ahs_register": {
@@ -209,8 +209,8 @@ zero_program_2 = convert_unit(
 @pytest.mark.parametrize(
     "program, steps",
     [
-        (zero_program, 1),
-        (zero_program_2, 4),
+        (big_program_with_only_driving_field, 1),
+        (big_program_with_only_shifting_field, 4),
     ],
 )
 def test_scipy_run_for_large_system(program, steps):

--- a/test/unit_tests/braket/analog_hamiltonian_simulator/test_rydberg_simulator.py
+++ b/test/unit_tests/braket/analog_hamiltonian_simulator/test_rydberg_simulator.py
@@ -185,6 +185,11 @@ def test_scipy_run_for_large_system():
     assert isinstance(result, AnalogHamiltonianSimulationTaskResult)
 
 
+def test_scipy_run_for_empty_program():
+    result = device.run(empty_program, steps=2)
+    assert isinstance(result, AnalogHamiltonianSimulationTaskResult)
+
+
 @pytest.mark.parametrize(
     "num_time_points, index_time, start_time",
     [


### PR DESCRIPTION
*Issue #, if available:*

We introduced a bug in [the PR 180](https://github.com/aws/amazon-braket-default-simulator-python/pull/180) because driving field (and shifting field) is a list of list. The list is of length 1 because there is only one driving field now. This PR is a more robust fix for the issues https://github.com/aws/amazon-braket-default-simulator-python/issues/168 and https://github.com/aws/amazon-braket-default-simulator-python/issues/176 because it also considers the case where there is only shifting fields, but no driving field.

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-default-simulator-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
